### PR TITLE
DRY by means of Either in SystemRelations part of SystemUsageService

### DIFF
--- a/Core.ApplicationServices/Interface/IItInterfaceService.cs
+++ b/Core.ApplicationServices/Interface/IItInterfaceService.cs
@@ -5,7 +5,7 @@ namespace Core.ApplicationServices.Interface
 {
     public interface IItInterfaceService
     {
-        Result<ItInterface,OperationFailure> Delete(int id);
+        Result<ItInterface, OperationFailure> Delete(int id);
         Result<ItInterface, OperationFailure> Create(ItInterface newInterface);
     }
 }

--- a/Core.ApplicationServices/Options/IOptionsService.cs
+++ b/Core.ApplicationServices/Options/IOptionsService.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Generic;
 using Core.DomainModel;
+using Core.DomainModel.Result;
 
 namespace Core.ApplicationServices.Options
 {
-    public interface IOptionsService<TReference, out TOption> where TOption : OptionEntity<TReference>
+    public interface IOptionsService<TReference, TOption> where TOption : OptionEntity<TReference>
     {
         IEnumerable<TOption> GetAvailableOptions(int organizationId);
+        Maybe<TOption> GetAvailableOption(int organizationId, int optionId);
     }
 }

--- a/Core.ApplicationServices/Options/OptionsService.cs
+++ b/Core.ApplicationServices/Options/OptionsService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Core.DomainModel;
+using Core.DomainModel.Result;
 using Core.DomainServices;
 using Core.DomainServices.Extensions;
 
@@ -23,6 +24,15 @@ namespace Core.ApplicationServices.Options
 
         public IEnumerable<TOption> GetAvailableOptions(int organizationId)
         {
+            var allOptions = GetAvailableOptionsFromOrganization(organizationId);
+
+            return allOptions
+                .OrderBy(option => option.Name)
+                .ToList();
+        }
+
+        private IQueryable<TOption> GetAvailableOptionsFromOrganization(int organizationId)
+        {
             var activeOptionIds = _localOptionRepository
                 .AsQueryable()
                 .ByOrganizationId(organizationId)
@@ -41,10 +51,14 @@ namespace Core.ApplicationServices.Options
                 .ExceptEntitiesWithIds(activeOptionIds)
                 .Where(x => x.IsObligatory); //Add enabled global options which are obligatory as well
 
-            return allObligatory
-                .Concat(allLocallyEnabled)
-                .OrderBy(option => option.Name)
-                .ToList();
+            var allOptions = allObligatory.Concat(allLocallyEnabled);
+            return allOptions;
+        }
+
+        public Maybe<TOption> GetAvailableOption(int organizationId, int optionId)
+        {
+            return GetAvailableOptionsFromOrganization(organizationId)
+                .FirstOrDefault(option => option.Id == optionId);
         }
     }
 }

--- a/Core.ApplicationServices/SystemUsage/IItSystemUsageService.cs
+++ b/Core.ApplicationServices/SystemUsage/IItSystemUsageService.cs
@@ -46,13 +46,13 @@ namespace Core.ApplicationServices.SystemUsage
         /// <returns></returns>
         Result<SystemRelation, OperationFailure> GetRelation(int fromSystemUsageId, int relationId);
         /// <summary>
-        /// Gets the systems which the target system can relate to
+        /// Gets the systems which the "from" system can relate to
         /// </summary>
         /// <param name="fromSystemUsageId"></param>
         /// <param name="nameContent"></param>
         /// <param name="pageSize"></param>
         /// <returns></returns>
-        Result<IEnumerable<ItSystemUsage>, OperationError> GetAvailableRelationTargets(int fromSystemUsageId, Maybe<string> nameContent, int pageSize);
+        Result<IEnumerable<ItSystemUsage>, OperationError> GetSystemUsagesWhichCanBeRelatedTo(int fromSystemUsageId, Maybe<string> nameContent, int pageSize);
         /// <summary>
         /// Gets the valid options for the given system relation
         /// </summary>

--- a/Core.ApplicationServices/SystemUsage/IItSystemUsageService.cs
+++ b/Core.ApplicationServices/SystemUsage/IItSystemUsageService.cs
@@ -72,7 +72,6 @@ namespace Core.ApplicationServices.SystemUsage
         /// <param name="toContractId">Id of the specific "to" system usage contract to replace the existing system relation value</param>
         /// <param name="toFrequencyTypeId">Id of the specific "to" system frequency type to replace the existing system relation value</param>
         /// <returns></returns>
-        Result<SystemRelation, OperationError> ModifyRelation(int fromSystemUsageId, int relationId, int toSystemUsageId, string description, string reference,
-            int? toInterfaceId, int? toContractId, int? toFrequencyTypeId);
+        Result<SystemRelation, OperationError> ModifyRelation(int fromSystemUsageId, int relationId, int toSystemUsageId, string description, string reference, int? toInterfaceId, int? toContractId, int? toFrequencyTypeId);
     }
 }

--- a/Core.ApplicationServices/SystemUsage/ItSystemUsageService.cs
+++ b/Core.ApplicationServices/SystemUsage/ItSystemUsageService.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using Core.ApplicationServices.Authorization;
-using Core.ApplicationServices.Interface;
 using Core.ApplicationServices.Model.SystemUsage;
 using Core.ApplicationServices.Options;
 using Core.DomainModel;
@@ -151,123 +151,86 @@ namespace Core.ApplicationServices.SystemUsage
             int? frequencyId,
             int? contractId)
         {
-            var fromSystemUsage = _usageRepository.GetByKey(fromSystemUsageId);
-            var toSystemUsage = _usageRepository.GetByKey(toSystemUsageId);
-            var toContract = Maybe<ItContract>.None;
-            var toFrequency = Maybe<RelationFrequencyType>.None;
-            var toInterface = Maybe<ItInterface>.None;
+            var operationContext = new SystemRelationOperationContext(
+                new SystemRelationOperationParameters(fromSystemUsageId, toSystemUsageId, interfaceId, frequencyId, contractId),
+                new SystemRelationOperationEntities());
 
-            if (fromSystemUsage == null)
-                return new OperationError("Source not found", OperationFailure.NotFound);
-
-            if (toSystemUsage == null)
-                return new OperationError("Destination could not be found", OperationFailure.BadInput);
-
-            if (!_authorizationContext.AllowModify(fromSystemUsage))
-                return Result<SystemRelation, OperationError>.Failure(OperationFailure.Forbidden);
-
-            if (frequencyId.HasValue)
-            {
-                toFrequency = _frequencyService.GetAvailableOption(fromSystemUsage.OrganizationId, frequencyId.Value);
-
-                if (toFrequency.IsNone)
-                {
-                    return new OperationError("Frequency type is not available in the organization", OperationFailure.BadInput);
-                }
-            }
-
-            if (interfaceId.HasValue)
-            {
-                toInterface = _interfaceRepository.GetByKey(interfaceId.Value);
-                if (toInterface.IsNone)
-                {
-                    return new OperationError("The provided interface id does not point to a valid interface",OperationFailure.BadInput);
-                }
-            }
-
-            if (contractId.HasValue)
-            {
-                toContract = _contractRepository.GetById(contractId.Value);
-                if (toContract.IsNone)
-                {
-                    return new OperationError("Contract id does not point to a valid contract", OperationFailure.BadInput);
-                }
-            }
-
-            var result = fromSystemUsage.AddUsageRelationTo(_userContext.UserEntity, toSystemUsage, toInterface, description, reference, toFrequency, toContract);
-            if (result.Ok)
-            {
-                _usageRepository.Save();
-            }
-            return result;
+            return
+                LoadFromSystemUsage(operationContext)
+                    .Select(LoadToSystemUsage)
+                    .Select(WithAuthorizedModificationAccess)
+                    .Select(LoadFrequency)
+                    .Select(LoadInterface)
+                    .Select(LoadContract)
+                    .Match
+                    (
+                        onSuccess: context =>
+                        {
+                            var fromSystemUsage = context.Entities.FromSystemUsage;
+                            var toSystemUsage = context.Entities.ToSystemUsage;
+                            var frequency = context.Entities.Frequency;
+                            var contract = context.Entities.Contract;
+                            var relationInterface = context.Entities.Interface;
+                            return fromSystemUsage
+                                .AddUsageRelationTo(_userContext.UserEntity, toSystemUsage, relationInterface, description, reference, frequency, contract)
+                                .Match<Result<SystemRelation, OperationError>>
+                                (
+                                    onSuccess: createdRelation =>
+                                    {
+                                        _usageRepository.Save();
+                                        return createdRelation;
+                                    },
+                                    onFailure: error => error
+                                );
+                        },
+                        onFailure: error => error
+                    );
         }
 
         public Result<SystemRelation, OperationError> ModifyRelation(
-            int fromSystemUsageId, 
-            int relationId, 
-            int toSystemUsageId, 
+            int fromSystemUsageId,
+            int relationId,
+            int toSystemUsageId,
             string changedDescription,
             string changedReference,
             int? toInterfaceId,
             int? toContractId,
             int? toFrequencyId)
         {
-            var fromSystemUsage = _usageRepository.GetByKey(fromSystemUsageId);
-            if (fromSystemUsage == null)
-            {
-                return new OperationError("Source not found", OperationFailure.NotFound);
-            }
+            var operationContext = new SystemRelationOperationContext(
+                new SystemRelationOperationParameters(fromSystemUsageId, toSystemUsageId, toInterfaceId, toFrequencyId, toContractId),
+                new SystemRelationOperationEntities());
 
-            if (!_authorizationContext.AllowModify(fromSystemUsage))
-            {
-                return Result<SystemRelation, OperationError>.Failure(OperationFailure.Forbidden);
-            }
-
-            var toSystemUsage = _usageRepository.GetByKey(toSystemUsageId);
-            if (toSystemUsage == null)
-            {
-                return new OperationError("Target system usage not found", OperationFailure.BadInput);
-            }
-
-            var toContract = Maybe<ItContract>.None;
-            if (toContractId.HasValue)
-            {
-                toContract = _contractRepository.GetById(toContractId.Value);
-                if (toContract.IsNone)
-                {
-                    return new OperationError("Contract id does not point to a valid contract", OperationFailure.BadInput);
-                }
-            }
-
-            var toFrequency = Maybe<RelationFrequencyType>.None;
-            if (toFrequencyId.HasValue)
-            {
-                toFrequency = _frequencyService.GetAvailableOption(fromSystemUsage.OrganizationId, toFrequencyId.Value);
-
-                if (toFrequency.IsNone)
-                {
-                    return new OperationError("Frequency type is not available in the organization", OperationFailure.BadInput);
-                }
-            }
-
-            var toInterface = Maybe<ItInterface>.None;
-            if (toInterfaceId.HasValue)
-            {
-                toInterface = _interfaceRepository.GetByKey(toInterfaceId.Value);
-                if (toInterface.IsNone)
-                {
-                    return new OperationError("The provided interface id does not point to a valid interface", OperationFailure.BadInput);
-                }
-            }
-
-            var result = fromSystemUsage.ModifyUsageRelation(_userContext.UserEntity, relationId, toSystemUsage, 
-                changedDescription, changedReference, toInterface, toContract, toFrequency);
-            if (result.Ok)
-            {
-                _usageRepository.Save();
-            }
-
-            return result;
+            return
+                LoadFromSystemUsage(operationContext)
+                    .Select(LoadToSystemUsage)
+                    .Select(WithAuthorizedModificationAccess)
+                    .Select(LoadFrequency)
+                    .Select(LoadInterface)
+                    .Select(LoadContract)
+                    .Match
+                    (
+                        onSuccess: context =>
+                        {
+                            var fromSystemUsage = context.Entities.FromSystemUsage;
+                            var toSystemUsage = context.Entities.ToSystemUsage;
+                            var frequency = context.Entities.Frequency;
+                            var contract = context.Entities.Contract;
+                            var relationInterface = context.Entities.Interface;
+                            return fromSystemUsage
+                                .ModifyUsageRelation(_userContext.UserEntity, relationId, toSystemUsage, changedDescription, changedReference, relationInterface, contract, frequency)
+                                .Match<Result<SystemRelation, OperationError>>
+                                (
+                                    onSuccess: createdRelation =>
+                                    {
+                                        _usageRepository.Save();
+                                        return createdRelation;
+                                    },
+                                    onFailure: error => error
+                                );
+                        },
+                        onFailure: error => error
+                    );
         }
 
         public Result<IEnumerable<SystemRelation>, OperationError> GetRelations(int fromSystemUsageId)
@@ -407,5 +370,131 @@ namespace Core.ApplicationServices.SystemUsage
 
             return new RelationOptionsDTO(source, destination, exposedInterfaces, contracts, availableFrequencyTypes);
         }
+
+        #region Parameter Types
+
+        private class SystemRelationOperationParameters
+        {
+            public int FromSystemUsageId { get; }
+            public int ToSystemUsageId { get; }
+            public int? InterfaceId { get; }
+            public int? FrequencyId { get; }
+            public int? ContractId { get; }
+
+            public SystemRelationOperationParameters(int fromSystemUsageId, int systemUsageId, int? interfaceId, int? frequencyId, int? contractId)
+            {
+                FromSystemUsageId = fromSystemUsageId;
+                ToSystemUsageId = systemUsageId;
+                InterfaceId = interfaceId;
+                FrequencyId = frequencyId;
+                ContractId = contractId;
+            }
+        }
+
+        private class SystemRelationOperationEntities
+        {
+            public ItSystemUsage FromSystemUsage { get; set; }
+            public ItSystemUsage ToSystemUsage { get; set; }
+            public Maybe<ItInterface> Interface { get; set; }
+            public Maybe<RelationFrequencyType> Frequency { get; set; }
+            public Maybe<ItContract> Contract { get; set; }
+        }
+
+        private class SystemRelationOperationContext
+        {
+            public SystemRelationOperationParameters Input { get; }
+            public SystemRelationOperationEntities Entities { get; }
+
+            public SystemRelationOperationContext(SystemRelationOperationParameters input, SystemRelationOperationEntities entities)
+            {
+                Input = input;
+                Entities = entities;
+            }
+        }
+
+        #endregion Parameter Types
+        #region helpers
+        private Result<SystemRelationOperationContext, OperationError> LoadFromSystemUsage(SystemRelationOperationContext context)
+        {
+            var fromSystemUsage = _usageRepository.GetByKey(context.Input.FromSystemUsageId);
+            if (fromSystemUsage == null)
+                return new OperationError("'From' not found", OperationFailure.NotFound);
+
+            context.Entities.FromSystemUsage = fromSystemUsage;
+            return context;
+        }
+
+        private Result<SystemRelationOperationContext, OperationError> WithAuthorizedModificationAccess(SystemRelationOperationContext context)
+        {
+            return !_authorizationContext.AllowModify(context.Entities.FromSystemUsage)
+                ? Result<SystemRelationOperationContext, OperationError>.Failure(OperationFailure.Forbidden)
+                : context;
+        }
+
+        private Result<SystemRelationOperationContext, OperationError> LoadToSystemUsage(SystemRelationOperationContext context)
+        {
+            var toSystemUsage = _usageRepository.GetByKey(context.Input.ToSystemUsageId);
+
+            if (toSystemUsage == null)
+                return new OperationError("'To' could not be found", OperationFailure.BadInput);
+
+            context.Entities.ToSystemUsage = toSystemUsage;
+            return context;
+        }
+
+        private Result<SystemRelationOperationContext, OperationError> LoadFrequency(SystemRelationOperationContext context)
+        {
+            var toFrequency = Maybe<RelationFrequencyType>.None;
+            var frequencyId = context.Input.FrequencyId;
+            if (frequencyId.HasValue)
+            {
+                toFrequency = _frequencyService.GetAvailableOption(context.Entities.FromSystemUsage.OrganizationId, frequencyId.Value);
+
+                if (toFrequency.IsNone)
+                {
+                    return new OperationError("Frequency type is not available in the organization", OperationFailure.BadInput);
+                }
+            }
+
+            context.Entities.Frequency = toFrequency.GetValueOrDefault();
+            return context;
+        }
+
+        private Result<SystemRelationOperationContext, OperationError> LoadInterface(SystemRelationOperationContext context)
+        {
+            var toInterface = Maybe<ItInterface>.None;
+            var interfaceId = context.Input.InterfaceId;
+            if (interfaceId.HasValue)
+            {
+                toInterface = _interfaceRepository.GetByKey(interfaceId.Value);
+                if (toInterface.IsNone)
+                {
+                    return new OperationError("The provided interface id does not point to a valid interface", OperationFailure.BadInput);
+                }
+            }
+
+            context.Entities.Interface = toInterface.GetValueOrDefault();
+
+            return context;
+        }
+
+        private Result<SystemRelationOperationContext, OperationError> LoadContract(SystemRelationOperationContext context)
+        {
+            var toContract = Maybe<ItContract>.None;
+            var contractId = context.Input.ContractId;
+            if (contractId.HasValue)
+            {
+                toContract = _contractRepository.GetById(contractId.Value);
+                if (toContract.IsNone)
+                {
+                    return new OperationError("Contract id does not point to a valid contract", OperationFailure.BadInput);
+                }
+            }
+
+            context.Entities.Contract = toContract.GetValueOrDefault();
+
+            return context;
+        }
+        #endregion helpers
     }
 }

--- a/Core.ApplicationServices/SystemUsage/ItSystemUsageService.cs
+++ b/Core.ApplicationServices/SystemUsage/ItSystemUsageService.cs
@@ -347,7 +347,11 @@ namespace Core.ApplicationServices.SystemUsage
 
         public Result<RelationOptionsDTO, OperationError> GetAvailableOptions(int fromSystemUsageId, int toSystemUsageId)
         {
-            var operationContext = new SystemRelationOperationContext(new SystemRelationOperationParameters { FromSystemUsageId = fromSystemUsageId }, new SystemRelationOperationEntities());
+            var operationContext = new SystemRelationOperationContext(new SystemRelationOperationParameters
+            {
+                FromSystemUsageId = fromSystemUsageId,
+                ToSystemUsageId = toSystemUsageId
+            }, new SystemRelationOperationEntities());
 
             return
                 LoadFromSystemUsage(operationContext)

--- a/Core.DomainModel/ItSystemUsage/ItSystemUsage.cs
+++ b/Core.DomainModel/ItSystemUsage/ItSystemUsage.cs
@@ -433,7 +433,7 @@ namespace Core.DomainModel.ItSystemUsage
         public Result<SystemRelation, OperationError> AddUsageRelationTo(
             User activeUser,
             ItSystemUsage toSystemUsage,
-            int? interfaceId,
+            Maybe<ItInterface> relationInterface,
             string description,
             string reference,
             Maybe<RelationFrequencyType> targetFrequency,
@@ -452,7 +452,7 @@ namespace Core.DomainModel.ItSystemUsage
                 LastChanged = DateTime.Now
             };
 
-            var updateRelationResult = UpdateRelation(newRelation, toSystemUsage, description, reference, interfaceId, targetContract, targetFrequency);
+            var updateRelationResult = UpdateRelation(newRelation, toSystemUsage, description, reference, relationInterface, targetContract, targetFrequency);
 
             if (updateRelationResult.Failed)
             {
@@ -472,7 +472,7 @@ namespace Core.DomainModel.ItSystemUsage
             ItSystemUsage toSystemUsage,
             string changedDescription,
             string changedFrequency,
-            int? interfaceId,
+            Maybe<ItInterface> relationInterface,
             Maybe<ItContract.ItContract> toContract, 
             Maybe<RelationFrequencyType> toFrequency)
         {
@@ -489,7 +489,7 @@ namespace Core.DomainModel.ItSystemUsage
 
             var relation = relationResult.Value;
 
-            return UpdateRelation(relation, toSystemUsage, changedDescription, changedFrequency, interfaceId, toContract, toFrequency);
+            return UpdateRelation(relation, toSystemUsage, changedDescription, changedFrequency, relationInterface, toContract, toFrequency);
         }
 
         public Result<SystemRelation, OperationFailure> RemoveUsageRelation(int relationId)
@@ -521,6 +521,11 @@ namespace Core.DomainModel.ItSystemUsage
             return GetExposedInterfaces().FirstOrDefault(x => x.Id == interfaceId);
         }
 
+        public bool HasExposedInterface(int interfaceId)
+        {
+            return GetExposedInterface(interfaceId).HasValue;
+        }
+
         public Maybe<SystemRelation> GetUsageRelation(int relationId)
         {
             return UsageRelations.FirstOrDefault(r => r.Id == relationId);
@@ -530,14 +535,14 @@ namespace Core.DomainModel.ItSystemUsage
             ItSystemUsage toSystemUsage,
             string changedDescription,
             string changedReference,
-            int? interfaceId,
+            Maybe<ItInterface> relationInterface,
             Maybe<ItContract.ItContract> toContract, 
             Maybe<RelationFrequencyType> toFrequency)
         {
             return relation
                 .SetRelationTo(toSystemUsage)
                 .Select(_ => _.SetDescription(changedDescription))
-                .Select(_ => _.SetRelationInterface(interfaceId))
+                .Select(_ => _.SetRelationInterface(relationInterface))
                 .Select(_ => _.SetContract(toContract))
                 .Select(_ => _.SetFrequency(toFrequency))
                 .Select(_ => _.SetReference(changedReference));

--- a/Core.DomainModel/ItSystemUsage/SystemRelation.cs
+++ b/Core.DomainModel/ItSystemUsage/SystemRelation.cs
@@ -117,26 +117,21 @@ namespace Core.DomainModel.ItSystemUsage
         /// <summary>
         /// Replace relation interface
         /// </summary>
-        /// <param name="targetInterfaceId">Replacement interface to be used on the relation. NULL is allowed</param>
-        public Result<SystemRelation, OperationError> SetRelationInterface(int? targetInterfaceId)
+        /// <param name="relationInterface">Replacement interface to be used on the relation. None is allowed</param>
+        public Result<SystemRelation, OperationError> SetRelationInterface(Maybe<ItInterface> relationInterface)
         {
             if (ToSystemUsage == null)
                 throw new InvalidOperationException("Cannot set interface to unknown 'To' system");
 
-            if (targetInterfaceId.HasValue)
+            if (relationInterface.HasValue)
             {
-                var exposedInterface = ToSystemUsage.GetExposedInterface(targetInterfaceId.Value);
-                if (exposedInterface.IsNone)
+                if (!ToSystemUsage.HasExposedInterface(relationInterface.Value.Id))
                 {
                     return new OperationError("Cannot set interface which is not exposed by the 'to' system", OperationFailure.BadInput);
                 }
+            }
 
-                RelationInterface = exposedInterface.Value;
-            }
-            else
-            {
-                RelationInterface = null;
-            }
+            RelationInterface = relationInterface.GetValueOrDefault();
 
             return this;
         }

--- a/Presentation.Web/Controllers/API/SystemRelationController.cs
+++ b/Presentation.Web/Controllers/API/SystemRelationController.cs
@@ -78,10 +78,10 @@ namespace Presentation.Web.Controllers.API
         }
 
         [HttpGet]
-        [Route("options/{fromSystemUsageId}/available-destination-systems")]
-        public HttpResponseMessage GetAvailableDestinationSystems(int fromSystemUsageId, string nameContent, int amount)
+        [Route("options/{fromSystemUsageId}/systems-which-can-be-related-to")]
+        public HttpResponseMessage GetSystemUsagesWhichCanBeRelatedTo(int fromSystemUsageId, string nameContent, int amount)
         {
-            return _usageService.GetAvailableRelationTargets(fromSystemUsageId, nameContent.FromString(), amount)
+            return _usageService.GetSystemUsagesWhichCanBeRelatedTo(fromSystemUsageId, nameContent.FromString(), amount)
                 .Match
                 (
                     onSuccess: systemUsages => Ok

--- a/Tests.Integration.Presentation.Web/Tools/SystemRelationHelper.cs
+++ b/Tests.Integration.Presentation.Web/Tools/SystemRelationHelper.cs
@@ -71,7 +71,7 @@ namespace Tests.Integration.Presentation.Web.Tools
         public static async Task<IEnumerable<NamedEntityDTO>> GetAvailableDestinationSystemsAsync(int systemUsageId, string prefix, Cookie login = null)
         {
             login = login ?? await HttpApi.GetCookieAsync(OrganizationRole.GlobalAdmin);
-            var url = TestEnvironment.CreateUrl($"api/v1/systemrelations/options/{systemUsageId}/available-destination-systems?nameContent={prefix}&amount=25");
+            var url = TestEnvironment.CreateUrl($"api/v1/systemrelations/options/{systemUsageId}/systems-which-can-be-related-to?nameContent={prefix}&amount=25");
 
             using (var response = await HttpApi.GetWithCookieAsync(url, login))
             {

--- a/Tests.Unit.Core.ApplicationServices/ApplicationServices/ItSystemUsageServiceTest.cs
+++ b/Tests.Unit.Core.ApplicationServices/ApplicationServices/ItSystemUsageServiceTest.cs
@@ -634,25 +634,6 @@ namespace Tests.Unit.Core.ApplicationServices
         }
 
         [Fact]
-        public void GetSystemUsagesWhichCanBeRelatedTo_Returns_Forbidden_Due_To_Bad_InOrg_Access()
-        {
-            //Arrange
-            var id = A<int>();
-            var organizationId = A<int>();
-            var itSystemUsage = new ItSystemUsage { OrganizationId = organizationId };
-            ExpectGetUsageByKeyReturns(id, itSystemUsage);
-            ExpectAllowReadReturns(itSystemUsage, true);
-            ExpectGetOrganizationReadAccessReturns(itSystemUsage, OrganizationDataReadAccessLevel.Public);
-
-            //Act
-            var result = _sut.GetSystemUsagesWhichCanBeRelatedTo(id, Maybe<string>.None, 2);
-
-            //Assert
-            Assert.False(result.Ok);
-            Assert.Equal(OperationFailure.Forbidden, result.Error.FailureType);
-        }
-
-        [Fact]
         public void GetSystemUsagesWhichCanBeRelatedTo_Without_NameContent_Returns_AvailableSystemUsages()
         {
             //Arrange
@@ -666,7 +647,6 @@ namespace Tests.Unit.Core.ApplicationServices
 
             ExpectGetUsageByKeyReturns(fromItSystemUsage.Id, fromItSystemUsage);
             ExpectAllowReadReturns(fromItSystemUsage, true);
-            ExpectGetOrganizationReadAccessReturns(fromItSystemUsage, OrganizationDataReadAccessLevel.All);
             _systemRepository.Setup(x => x.GetSystemsInUse(organizationId)).Returns(new[] { itSystem1, itSystem2, itSystem3 }.AsQueryable());
             _usageRepository.Setup(x => x.AsQueryable()).Returns(new[] { includedSystemUsage1, includedSystemUsage2, fromItSystemUsage }.AsQueryable());
 
@@ -687,11 +667,6 @@ namespace Tests.Unit.Core.ApplicationServices
                 ItSystemId = itSystem.Id,
                 ItSystem = itSystem
             };
-        }
-
-        private void ExpectGetOrganizationReadAccessReturns(ItSystemUsage itSystemUsage, OrganizationDataReadAccessLevel value)
-        {
-            _authorizationContext.Setup(x => x.GetOrganizationReadAccessLevel(itSystemUsage.OrganizationId)).Returns(value);
         }
 
         private ItSystem CreateItSystem()

--- a/Tests.Unit.Core.ApplicationServices/ApplicationServices/ItSystemUsageServiceTest.cs
+++ b/Tests.Unit.Core.ApplicationServices/ApplicationServices/ItSystemUsageServiceTest.cs
@@ -302,7 +302,7 @@ namespace Tests.Unit.Core.ApplicationServices
             var result = _sut.AddRelation(sourceId, A<int>(), null, A<string>(), A<string>(), null, null);
 
             //Assert
-            AssertAddRelationError(result, OperationFailure.NotFound, "Source not found");
+            AssertAddRelationError(result, OperationFailure.NotFound, "'From' not found");
         }
 
         [Fact]
@@ -319,7 +319,7 @@ namespace Tests.Unit.Core.ApplicationServices
             var result = _sut.AddRelation(sourceId, destinationId, null, A<string>(), A<string>(), null, null);
 
             //Assert
-            AssertAddRelationError(result, OperationFailure.BadInput, "Destination could not be found");
+            AssertAddRelationError(result, OperationFailure.BadInput, "'To' could not be found");
         }
 
         [Fact]

--- a/Tests.Unit.Core.ApplicationServices/ApplicationServices/ItSystemUsageServiceTest.cs
+++ b/Tests.Unit.Core.ApplicationServices/ApplicationServices/ItSystemUsageServiceTest.cs
@@ -34,6 +34,7 @@ namespace Tests.Unit.Core.ApplicationServices
         private readonly User _activeUser;
         private readonly Mock<ITransactionManager> _transactionManager;
         private readonly Mock<IGenericRepository<SystemRelation>> _relationRepositoryMock;
+        private readonly Mock<IGenericRepository<ItInterface>> _interfaceRepository;
 
         public ItSystemUsageServiceTest()
         {
@@ -47,6 +48,7 @@ namespace Tests.Unit.Core.ApplicationServices
             _userContext.Setup(x => x.UserEntity).Returns(_activeUser);
             _transactionManager = new Mock<ITransactionManager>();
             _relationRepositoryMock = new Mock<IGenericRepository<SystemRelation>>();
+            _interfaceRepository = new Mock<IGenericRepository<ItInterface>>();
             _sut = new ItSystemUsageService(
                 _usageRepository.Object,
                 _authorizationContext.Object,
@@ -55,6 +57,7 @@ namespace Tests.Unit.Core.ApplicationServices
                 _optionsService.Object,
                 _userContext.Object,
                 _relationRepositoryMock.Object,
+                _interfaceRepository.Object,
                 _transactionManager.Object,
                 Mock.Of<ILogger>());
         }
@@ -354,7 +357,7 @@ namespace Tests.Unit.Core.ApplicationServices
             ExpectGetUsageByKeyReturns(sourceId, source);
             ExpectGetUsageByKeyReturns(destinationId, new ItSystemUsage());
             ExpectAllowModifyReturns(source, true);
-            ExpectGetAvailableOptionsReturns(source, new RelationFrequencyType { Id = frequencyId + 1 });
+            ExpectGetAvailableOptionsReturns(source, frequencyId, Maybe<RelationFrequencyType>.None);
 
             //Act
             var result = _sut.AddRelation(sourceId, destinationId, null, A<string>(), A<string>(), frequencyId, null);
@@ -379,7 +382,7 @@ namespace Tests.Unit.Core.ApplicationServices
             ExpectGetUsageByKeyReturns(sourceId, source);
             ExpectGetUsageByKeyReturns(destinationId, new ItSystemUsage() { Id = sourceId + 1, OrganizationId = source.OrganizationId });
             ExpectAllowModifyReturns(source, true);
-            ExpectGetAvailableOptionsReturns(source, new RelationFrequencyType { Id = frequencyId });
+            ExpectGetAvailableOptionsReturns(source, frequencyId, new RelationFrequencyType { Id = frequencyId });
             _contractRepository.Setup(x => x.GetById(contractId)).Returns(default(ItContract));
 
             //Act
@@ -405,7 +408,7 @@ namespace Tests.Unit.Core.ApplicationServices
             ExpectGetUsageByKeyReturns(sourceId, source);
             ExpectGetUsageByKeyReturns(destinationId, new ItSystemUsage() { Id = sourceId + 1, OrganizationId = source.OrganizationId });
             ExpectAllowModifyReturns(source, true);
-            ExpectGetAvailableOptionsReturns(source, new RelationFrequencyType { Id = frequencyId });
+            ExpectGetAvailableOptionsReturns(source, frequencyId, new RelationFrequencyType { Id = frequencyId });
             _contractRepository.Setup(x => x.GetById(contractId)).Returns(new ItContract() { OrganizationId = source.OrganizationId });
 
             //Act
@@ -735,9 +738,9 @@ namespace Tests.Unit.Core.ApplicationServices
             _usageRepository.Setup(x => x.GetByKey(id)).Returns(itSystemUsage);
         }
 
-        private void ExpectGetAvailableOptionsReturns(ItSystemUsage source, params RelationFrequencyType[] results)
+        private void ExpectGetAvailableOptionsReturns(ItSystemUsage source, int optionId, Maybe<RelationFrequencyType> response)
         {
-            _optionsService.Setup(x => x.GetAvailableOptions(source.OrganizationId)).Returns(new List<RelationFrequencyType>(results));
+            _optionsService.Setup(x => x.GetAvailableOption(source.OrganizationId, optionId)).Returns(response);
         }
 
         private void ExpectAllowModifyReturns(ItSystemUsage source, bool value)

--- a/Tests.Unit.Core.ApplicationServices/Model/ItSystemUsageTest.cs
+++ b/Tests.Unit.Core.ApplicationServices/Model/ItSystemUsageTest.cs
@@ -25,14 +25,14 @@ namespace Tests.Unit.Core.Model
         [Fact]
         public void AddUsageRelationTo_Throws_If_ActiveUser_Is_Null()
         {
-            Assert.Throws<ArgumentNullException>(() => _sut.AddUsageRelationTo(null, new ItSystemUsage(), A<int?>(),
+            Assert.Throws<ArgumentNullException>(() => _sut.AddUsageRelationTo(null, new ItSystemUsage(), Maybe<ItInterface>.None, 
                 A<string>(), A<string>(), Maybe<RelationFrequencyType>.None, Maybe<ItContract>.None));
         }
 
         [Fact]
         public void AddUsageRelationTo_Throws_If_Destination_Is_Null()
         {
-            Assert.Throws<ArgumentNullException>(() => _sut.AddUsageRelationTo(new User(), null, A<int?>(),
+            Assert.Throws<ArgumentNullException>(() => _sut.AddUsageRelationTo(new User(), null, Maybe<ItInterface>.None,
                 A<string>(), A<string>(), Maybe<RelationFrequencyType>.None, Maybe<ItContract>.None));
         }
 
@@ -46,7 +46,7 @@ namespace Tests.Unit.Core.Model
             };
 
             //Act
-            var result = _sut.AddUsageRelationTo(new User(), destination, A<int?>(), A<string>(), A<string>(), Maybe<RelationFrequencyType>.None, Maybe<ItContract>.None);
+            var result = _sut.AddUsageRelationTo(new User(), destination, Maybe<ItInterface>.None, A<string>(), A<string>(), Maybe<RelationFrequencyType>.None, Maybe<ItContract>.None);
 
             //Assert
             AssertErrorResult(result, "'From' cannot equal 'To'", OperationFailure.BadInput);
@@ -63,7 +63,7 @@ namespace Tests.Unit.Core.Model
             };
 
             //Act
-            var result = _sut.AddUsageRelationTo(new User(), destination, A<int?>(), A<string>(), A<string>(), Maybe<RelationFrequencyType>.None, Maybe<ItContract>.None);
+            var result = _sut.AddUsageRelationTo(new User(), destination, Maybe<ItInterface>.None, A<string>(), A<string>(), Maybe<RelationFrequencyType>.None, Maybe<ItContract>.None);
 
             //Assert
             AssertErrorResult(result, "Attempt to create relation to it-system in a different organization", OperationFailure.BadInput);
@@ -82,7 +82,7 @@ namespace Tests.Unit.Core.Model
             var itContract = new ItContract { OrganizationId = _sut.OrganizationId + 1 };
 
             //Act
-            var result = _sut.AddUsageRelationTo(new User(), destination, null, A<string>(), A<string>(), Maybe<RelationFrequencyType>.None, itContract);
+            var result = _sut.AddUsageRelationTo(new User(), destination, Maybe<ItInterface>.None, A<string>(), A<string>(), Maybe<RelationFrequencyType>.None, itContract);
 
             //Assert
             AssertErrorResult(result, "Attempt to create relation to it-contract in a different organization", OperationFailure.BadInput);
@@ -116,7 +116,7 @@ namespace Tests.Unit.Core.Model
 
 
             //Act
-            var result = _sut.AddUsageRelationTo(new User(), destination, interfaceId, A<string>(), A<string>(), Maybe<RelationFrequencyType>.None, itContract);
+            var result = _sut.AddUsageRelationTo(new User(), destination, new ItInterface(){Id = interfaceId}, A<string>(), A<string>(), Maybe<RelationFrequencyType>.None, itContract);
 
             //Assert
             AssertErrorResult(result, "Cannot set interface which is not exposed by the 'to' system", OperationFailure.BadInput);
@@ -131,6 +131,10 @@ namespace Tests.Unit.Core.Model
             _sut.ObjectOwner = objectOwner;
             var activeUser = new User();
             _sut.UsageRelations.Add(new SystemRelation(new ItSystemUsage()));
+            var itInterface = new ItInterface
+            {
+                Id = interfaceId
+            };
             var destination = new ItSystemUsage
             {
                 Id = A<int>(),
@@ -141,10 +145,7 @@ namespace Tests.Unit.Core.Model
                     {
                         new ItInterfaceExhibit
                         {
-                            ItInterface = new ItInterface
-                            {
-                                Id = interfaceId
-                            }
+                            ItInterface = itInterface
                         }
                     }
                 }
@@ -155,7 +156,7 @@ namespace Tests.Unit.Core.Model
             var reference = A<string>();
 
             //Act
-            var result = _sut.AddUsageRelationTo(activeUser, destination, interfaceId, description, reference, frequencyType, itContract);
+            var result = _sut.AddUsageRelationTo(activeUser, destination, itInterface, description, reference, frequencyType, itContract);
 
             //Assert
             Assert.True(result.Ok);


### PR DESCRIPTION
Reused boundary checks by using composable eithers with stream lined context model