### PR TITLE
makes sure "toggled" data fields are cleared when subfields are turne…

### DIFF
--- a/Core.ApplicationServices/GDPR/DataProcessingRegistrationApplicationService.cs
+++ b/Core.ApplicationServices/GDPR/DataProcessingRegistrationApplicationService.cs
@@ -275,7 +275,7 @@ namespace Core.ApplicationServices.GDPR
         {
             return Modify<DataProcessingRegistration>(id, registration =>
             {
-                registration.HasSubDataProcessors = state;
+                registration.SetHasSubDataProcessors(state);
                 return registration;
             });
         }
@@ -295,7 +295,7 @@ namespace Core.ApplicationServices.GDPR
         {
             return Modify<DataProcessingRegistration>(id, registration =>
             {
-                registration.IsAgreementConcluded = concluded;
+                registration.SetIsAgreementConcluded(concluded);
                 return registration;
             });
         }
@@ -313,7 +313,7 @@ namespace Core.ApplicationServices.GDPR
         {
             return Modify<DataProcessingRegistration>(id, registration =>
             {
-                registration.TransferToInsecureThirdCountries = transferToInsecureThirdCountries;
+                registration.SetTransferToInsecureThirdCountries(transferToInsecureThirdCountries);
                 return registration;
             });
         }

--- a/Core.DomainModel/GDPR/DataProcessingRegistration.cs
+++ b/Core.DomainModel/GDPR/DataProcessingRegistration.cs
@@ -46,7 +46,25 @@ namespace Core.DomainModel.GDPR
 
         public YesNoUndecidedOption? HasSubDataProcessors { get; set; }
 
+        public void SetHasSubDataProcessors(YesNoUndecidedOption hasSubDataProcessors)
+        {
+            HasSubDataProcessors = hasSubDataProcessors;
+            if (hasSubDataProcessors != YesNoUndecidedOption.Yes)
+            {
+                SubDataProcessors.Clear();
+            }
+        }
+
         public YesNoUndecidedOption? TransferToInsecureThirdCountries { get; set; }
+
+        public void SetTransferToInsecureThirdCountries(YesNoUndecidedOption transferToInsecureThirdCountries)
+        {
+            TransferToInsecureThirdCountries = transferToInsecureThirdCountries;
+            if (transferToInsecureThirdCountries != YesNoUndecidedOption.Yes)
+            {
+                InsecureCountriesSubjectToDataTransfer.Clear();
+            }
+        }
 
         public virtual ICollection<DataProcessingCountryOption> InsecureCountriesSubjectToDataTransfer { get; set; }
 
@@ -281,5 +299,14 @@ namespace Core.DomainModel.GDPR
         public YearMonthIntervalOption? OversightInterval { get; set; }
 
         public string OversightIntervalRemark { get; set; }
+
+        public void SetIsAgreementConcluded(YesNoIrrelevantOption concluded)
+        {
+            IsAgreementConcluded = concluded;
+            if (IsAgreementConcluded != YesNoIrrelevantOption.YES)
+            {
+                AgreementConcludedAt = null;
+            }
+        }
     }
 }

--- a/Presentation.Web/Controllers/API/DataProcessingRegistrationController.cs
+++ b/Presentation.Web/Controllers/API/DataProcessingRegistrationController.cs
@@ -339,7 +339,7 @@ namespace Presentation.Web.Controllers.API
 
             return _dataProcessingRegistrationApplicationService
                 .SetSubDataProcessorsState(id, value.Value)
-                .Match(_ => Ok(), FromOperationError);
+                .Match(dataProcessingRegistration => Ok(ToDTO(dataProcessingRegistration)), FromOperationError);
         }
 
         [HttpPatch]
@@ -388,7 +388,7 @@ namespace Presentation.Web.Controllers.API
 
             return _dataProcessingRegistrationApplicationService
                 .UpdateIsAgreementConcluded(id, concluded.Value)
-                .Match(_ => Ok(), FromOperationError);
+                .Match(dataProcessingRegistration => Ok(ToDTO(dataProcessingRegistration)), FromOperationError);
         }
 
         [HttpPatch]
@@ -420,7 +420,7 @@ namespace Presentation.Web.Controllers.API
 
             return _dataProcessingRegistrationApplicationService
                 .UpdateTransferToInsecureThirdCountries(id, value.Value)
-                .Match(_ => Ok(), FromOperationError);
+                .Match(dataProcessingRegistration => Ok(ToDTO(dataProcessingRegistration)), FromOperationError);
         }
 
         [HttpPatch]

--- a/Presentation.Web/app/components/data-processing/data-processing-registration-overview.controller.ts
+++ b/Presentation.Web/app/components/data-processing/data-processing-registration-overview.controller.ts
@@ -208,11 +208,10 @@
                             .withDataSourceName("AgreementConcludedAt")
                             .withTitle("Dato for indgåelse af databehandleraftale")
                             .withId("agreementConcludedAt")
-                            .withStandardWidth(150)
+                            .withStandardWidth(160)
                             .withFilteringOperation(Utility.KendoGrid.KendoGridColumnFiltering.Date)
                             .withRendering(dataItem => Helpers.RenderFieldsHelper.renderDate(dataItem.AgreementConcludedAt))
-                            .withExcelOutput(dataItem => Helpers.ExcelExportHelper.renderDate(dataItem.AgreementConcludedAt))
-                            .withInitialVisibility(false))
+                            .withExcelOutput(dataItem => Helpers.ExcelExportHelper.renderDate(dataItem.AgreementConcludedAt)))
                     .withColumn(builder =>
                         builder
                             .withDataSourceName("OversightInterval")

--- a/Presentation.Web/app/components/data-processing/tabs/data-processing-registration-tab-main.controller.ts
+++ b/Presentation.Web/app/components/data-processing/tabs/data-processing-registration-tab-main.controller.ts
@@ -333,8 +333,12 @@
             this.apiUseCaseFactory
                 .createUpdate("Databehandleraftale indgået", () => this.dataProcessingRegistrationService.updateIsAgreementConcluded(this.dataProcessingRegistration.id, isAgreementConcluded.optionalObjectContext))
                 .executeAsync(success => {
+                    if (isAgreementConcluded.optionalObjectContext !== Models.Api.Shared.YesNoIrrelevantOption.YES) {
+                        this.dataProcessingRegistration.agreementConcluded.optionalDateValue = null;
+                    }
                     this.dataProcessingRegistration.agreementConcluded.value = isAgreementConcluded.optionalObjectContext;
                     this.bindIsAgreementConcluded();
+                    this.bindAgreementConcludedAt();
                     return success;
                 });
         }
@@ -345,7 +349,11 @@
                 .createUpdate("Underdatabehandlere", () => this.dataProcessingRegistrationService.updateSubDataProcessorsState(this.dataProcessingRegistrationId, value))
                 .executeAsync(success => {
                     this.dataProcessingRegistration.hasSubDataProcessors = value;
+                    if (value !== Models.Api.Shared.YesNoUndecidedOption.Yes) {
+                        this.dataProcessingRegistration.subDataProcessors = [];
+                    }
                     this.bindHasSubDataProcessors();
+                    this.bindSubDataProcessors();
                     return success;
                 });
         }
@@ -355,6 +363,9 @@
                 .apiUseCaseFactory
                 .createUpdate("Overførsel til usikkert 3. land", () => this.dataProcessingRegistrationService.updateTransferToInsecureThirdCountry(this.dataProcessingRegistrationId, value))
                 .executeAsync(success => {
+                    if (value !== Models.Api.Shared.YesNoUndecidedOption.Yes) {
+                        this.dataProcessingRegistration.insecureThirdCountries = [];
+                    }
                     this.dataProcessingRegistration.transferToInsecureThirdCountries = value;
                     this.bindTransferToInsecureThirdCountries();
                     return success;
@@ -365,7 +376,7 @@
             var formattedDate = Helpers.DateStringFormat.fromDDMMYYYYToYYYYMMDD(agreementConcludedAt);
             if (!!formattedDate.convertedValue) {
                 return this.apiUseCaseFactory
-                    .createUpdate("Dato for databehandleraftale indgået", () => this.dataProcessingRegistrationService.updateAgreementConcludedAt(this.dataProcessingRegistration.id, formattedDate.convertedValue))
+                    .createUpdate("Dato for indgåelse af databehandleraftale", () => this.dataProcessingRegistrationService.updateAgreementConcludedAt(this.dataProcessingRegistration.id, formattedDate.convertedValue))
                     .executeAsync(success => {
                         this.dataProcessingRegistration.agreementConcluded.optionalDateValue = agreementConcludedAt;
                         this.bindAgreementConcludedAt();

--- a/Presentation.Web/app/components/data-processing/tabs/data-processing-registration-tab-main.controller.ts
+++ b/Presentation.Web/app/components/data-processing/tabs/data-processing-registration-tab-main.controller.ts
@@ -333,8 +333,8 @@
             this.apiUseCaseFactory
                 .createUpdate("Databehandleraftale indgået", () => this.dataProcessingRegistrationService.updateIsAgreementConcluded(this.dataProcessingRegistration.id, isAgreementConcluded.optionalObjectContext))
                 .executeAsync(success => {
-                    if (isAgreementConcluded.optionalObjectContext !== Models.Api.Shared.YesNoIrrelevantOption.YES) {
-                        this.dataProcessingRegistration.agreementConcluded.optionalDateValue = null;
+                    if (success.optionalServerDataPush) {
+                        this.dataProcessingRegistration.agreementConcluded = success.optionalServerDataPush.agreementConcluded;
                     }
                     this.dataProcessingRegistration.agreementConcluded.value = isAgreementConcluded.optionalObjectContext;
                     this.bindIsAgreementConcluded();
@@ -349,8 +349,8 @@
                 .createUpdate("Underdatabehandlere", () => this.dataProcessingRegistrationService.updateSubDataProcessorsState(this.dataProcessingRegistrationId, value))
                 .executeAsync(success => {
                     this.dataProcessingRegistration.hasSubDataProcessors = value;
-                    if (value !== Models.Api.Shared.YesNoUndecidedOption.Yes) {
-                        this.dataProcessingRegistration.subDataProcessors = [];
+                    if (success.optionalServerDataPush) {
+                        this.dataProcessingRegistration.subDataProcessors = success.optionalServerDataPush.subDataProcessors;
                     }
                     this.bindHasSubDataProcessors();
                     this.bindSubDataProcessors();
@@ -363,8 +363,8 @@
                 .apiUseCaseFactory
                 .createUpdate("Overførsel til usikkert 3. land", () => this.dataProcessingRegistrationService.updateTransferToInsecureThirdCountry(this.dataProcessingRegistrationId, value))
                 .executeAsync(success => {
-                    if (value !== Models.Api.Shared.YesNoUndecidedOption.Yes) {
-                        this.dataProcessingRegistration.insecureThirdCountries = [];
+                    if (success.optionalServerDataPush) {
+                        this.dataProcessingRegistration.insecureThirdCountries = success.optionalServerDataPush.insecureThirdCountries;
                     }
                     this.dataProcessingRegistration.transferToInsecureThirdCountries = value;
                     this.bindTransferToInsecureThirdCountries();

--- a/Presentation.Web/app/services/dataProcessingRegistrationService.ts
+++ b/Presentation.Web/app/services/dataProcessingRegistrationService.ts
@@ -41,6 +41,7 @@
 
     export interface IDataProcessingRegistrationPatchResult {
         valueModifiedTo: any;
+        optionalServerDataPush?: Models.DataProcessing.IDataProcessingRegistrationDTO;
     }
 
     export class DataProcessingRegistrationService implements IDataProcessingRegistrationService {
@@ -79,8 +80,10 @@
                 .patch<API.Models.IApiWrapper<any>>(url, payload)
                 .then(
                     response => {
+                        var res = response.data as { response: Models.DataProcessing.IDataProcessingRegistrationDTO };
                         return <IDataProcessingRegistrationPatchResult>{
                             valueModifiedTo: value,
+                            optionalServerDataPush: res.response
                         };
                     },
                     error => this.handleServerError(error)
@@ -281,8 +284,8 @@
             return this.simplePatch(this.getUriWithIdAndSuffix(dataProcessingRegistrationId, "agreement-concluded-at"), dateString);
         }
 
-        updateOversightInterval(dataProcessingRegistrationId: number, oversightInterval : Models.Api.Shared.YearMonthUndecidedIntervalOption) {
-            return this.simplePatch(this.getUriWithIdAndSuffix(dataProcessingRegistrationId, "oversight-interval"), oversightInterval );
+        updateOversightInterval(dataProcessingRegistrationId: number, oversightInterval: Models.Api.Shared.YearMonthUndecidedIntervalOption) {
+            return this.simplePatch(this.getUriWithIdAndSuffix(dataProcessingRegistrationId, "oversight-interval"), oversightInterval);
         }
 
         updateOversightIntervalRemark(dataProcessingRegistrationId: number, remark: string) {

--- a/Tests.Unit.Core.ApplicationServices/ApplicationServices/GDPR/DataProcessingRegistrationApplicationServiceTest.cs
+++ b/Tests.Unit.Core.ApplicationServices/ApplicationServices/GDPR/DataProcessingRegistrationApplicationServiceTest.cs
@@ -843,6 +843,29 @@ namespace Tests.Unit.Core.ApplicationServices.GDPR
             transaction.Verify(x => x.Commit());
         }
 
+        [Theory]
+        [InlineData(YesNoUndecidedOption.No)]
+        [InlineData(YesNoUndecidedOption.Undecided)]
+        public void Can_SetSubDataProcessorsState_Clears_SubdataProcessors_On_Negating_Setting(YesNoUndecidedOption clearingSetting)
+        {
+            //Arrange
+            var id = A<int>();
+            var registration = new DataProcessingRegistration(){SubDataProcessors = {new Organization()}};
+            ExpectRepositoryGetToReturn(id, registration);
+            ExpectAllowModifyReturns(registration, true);
+
+            var transaction = ExpectTransaction();
+
+            //Act
+            var result = _sut.SetSubDataProcessorsState(id, clearingSetting);
+
+            //Assert
+            Assert.True(result.Ok);
+            Assert.Equal(registration.HasSubDataProcessors, clearingSetting);
+            Assert.Empty(registration.SubDataProcessors);
+            transaction.Verify(x => x.Commit());
+        }
+
         [Fact]
         public void Cannot_SetSubDataProcessorsState_If_Dpr_Is_Not_Found()
         {
@@ -874,7 +897,7 @@ namespace Tests.Unit.Core.ApplicationServices.GDPR
             var oversightInterval = A<YearMonthIntervalOption>();
             var registration = new DataProcessingRegistration();
             ExpectRepositoryGetToReturn(id, registration);
-            ExpectAllowModifyReturns(registration,true);
+            ExpectAllowModifyReturns(registration, true);
             var transaction = new Mock<IDatabaseTransaction>();
             _transactionManagerMock.Setup(x => x.Begin(IsolationLevel.ReadCommitted)).Returns(transaction.Object);
 
@@ -883,9 +906,9 @@ namespace Tests.Unit.Core.ApplicationServices.GDPR
 
             //Assert
             Assert.True(result.Ok);
-            Assert.Equal(oversightInterval,result.Value.OversightInterval);
+            Assert.Equal(oversightInterval, result.Value.OversightInterval);
             transaction.Verify(x => x.Commit());
-            _repositoryMock.Verify(x => x.Update(registration),Times.Once);
+            _repositoryMock.Verify(x => x.Update(registration), Times.Once);
         }
 
         [Fact]
@@ -947,6 +970,31 @@ namespace Tests.Unit.Core.ApplicationServices.GDPR
             //Assert
             Assert.True(result.Ok);
             Assert.Equal(isAgreementConcluded, result.Value.IsAgreementConcluded);
+            transaction.Verify(x => x.Commit());
+            _repositoryMock.Verify(x => x.Update(registration), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(YesNoIrrelevantOption.IRRELEVANT)]
+        [InlineData(YesNoIrrelevantOption.NO)]
+        [InlineData(YesNoIrrelevantOption.UNDECIDED)]
+        public void Can_Update_IsAgreementConcluded_And_Clear_Date_On_Toggle_Off(YesNoIrrelevantOption clearingSetting)
+        {
+            //Arrange
+            var id = A<int>();
+            var registration = new DataProcessingRegistration {AgreementConcludedAt = A<DateTime>()};
+            ExpectRepositoryGetToReturn(id, registration);
+            ExpectAllowModifyReturns(registration, true);
+            var transaction = new Mock<IDatabaseTransaction>();
+            _transactionManagerMock.Setup(x => x.Begin(IsolationLevel.ReadCommitted)).Returns(transaction.Object);
+
+            //Act
+            var result = _sut.UpdateIsAgreementConcluded(id, clearingSetting);
+
+            //Assert
+            Assert.True(result.Ok);
+            Assert.Equal(clearingSetting, result.Value.IsAgreementConcluded);
+            Assert.Null(registration.AgreementConcludedAt);
             transaction.Verify(x => x.Commit());
             _repositoryMock.Verify(x => x.Update(registration), Times.Once);
         }
@@ -1024,6 +1072,29 @@ namespace Tests.Unit.Core.ApplicationServices.GDPR
             //Assert
             Assert.True(result.Ok);
             Assert.Equal(registration.TransferToInsecureThirdCountries, newValue);
+            transaction.Verify(x => x.Commit());
+        }
+
+        [Theory]
+        [InlineData(YesNoUndecidedOption.Undecided)]
+        [InlineData(YesNoUndecidedOption.No)]
+        public void Can_UpdateTransferToInsecureThirdCountries_Clears_ThirdCountries_On_Negating_Option(YesNoUndecidedOption clearingSetting)
+        {
+            //Arrange
+            var id = A<int>();
+            var registration = new DataProcessingRegistration(){InsecureCountriesSubjectToDataTransfer = {new DataProcessingCountryOption()}};
+            ExpectRepositoryGetToReturn(id, registration);
+            ExpectAllowModifyReturns(registration, true);
+
+            var transaction = ExpectTransaction();
+
+            //Act
+            var result = _sut.UpdateTransferToInsecureThirdCountries(id, clearingSetting);
+
+            //Assert
+            Assert.True(result.Ok);
+            Assert.Equal(registration.TransferToInsecureThirdCountries, clearingSetting);
+            Assert.Empty(registration.InsecureCountriesSubjectToDataTransfer);
             transaction.Verify(x => x.Commit());
         }
 


### PR DESCRIPTION
…d off

@JacobMalling Som du kan se har det nu konsekvens, når et felt slår andre felter fra. Det er også sådan vi skal gøre fremadrettet og i de resterende opgaver i backlog.