### PR TITLE
Feature/itsystem usage readmodel rebuild performance

### DIFF
--- a/Core.BackgroundJobs/Model/ReadModels/RebuildDataProcessingRegistrationReadModelsBatchJob.cs
+++ b/Core.BackgroundJobs/Model/ReadModels/RebuildDataProcessingRegistrationReadModelsBatchJob.cs
@@ -24,7 +24,7 @@ namespace Core.BackgroundJobs.Model.ReadModels
         private readonly IDataProcessingRegistrationReadModelRepository _readModelRepository;
         private readonly IDataProcessingRegistrationRepository _sourceRepository;
         private readonly ITransactionManager _transactionManager;
-        private const int BatchSize = 250;
+        private const int BatchSize = 25;
         public string Id => StandardJobIds.UpdateDataProcessingRegistrationReadModels;
 
         public RebuildDataProcessingRegistrationReadModelsBatchJob(

--- a/Core.BackgroundJobs/Model/ReadModels/RebuildItSystemUsageOverviewReadModelsBatchJob.cs
+++ b/Core.BackgroundJobs/Model/ReadModels/RebuildItSystemUsageOverviewReadModelsBatchJob.cs
@@ -24,7 +24,7 @@ namespace Core.BackgroundJobs.Model.ReadModels
         private readonly IItSystemUsageOverviewReadModelRepository _readModelRepository;
         private readonly IItSystemUsageRepository _sourceRepository;
         private readonly ITransactionManager _transactionManager;
-        private const int BatchSize = 100;
+        private const int BatchSize = 250;
         public string Id => StandardJobIds.UpdateItSystemUsageOverviewReadModels;
 
         public RebuildItSystemUsageOverviewReadModelsBatchJob(
@@ -48,7 +48,6 @@ namespace Core.BackgroundJobs.Model.ReadModels
             var completedUpdates = 0;
             try
             {
-
                 foreach (var pendingReadModelUpdate in _pendingReadModelUpdateRepository.GetMany(PendingReadModelUpdateSourceCategory.ItSystemUsage, BatchSize).ToList())
                 {
                     if (token.IsCancellationRequested)
@@ -76,7 +75,7 @@ namespace Core.BackgroundJobs.Model.ReadModels
                     }
                     completedUpdates++;
                     _pendingReadModelUpdateRepository.Delete(pendingReadModelUpdate);
-                    transaction.Commit();
+                    transaction.Commit(); 
                     _logger.Debug("Finished rebuilding read model for {category}:{sourceId}", pendingReadModelUpdate.Category, pendingReadModelUpdate.SourceId);
                 }
             }

--- a/Core.DomainServices/GDPR/DataProcessingRegistrationReadModelUpdate.cs
+++ b/Core.DomainServices/GDPR/DataProcessingRegistrationReadModelUpdate.cs
@@ -141,8 +141,6 @@ namespace Core.DomainServices.GDPR
                 var fullName = incomingRight.User.GetFullName().TrimEnd();
                 assignment.UserFullName = fullName.Substring(0, Math.Min(fullName.Length, 100));
             }
-
-            _roleAssignmentRepository.Save();
         }
 
         private void PatchOversightInterval(DataProcessingRegistration source,

--- a/Core.DomainServices/SystemUsage/BuildItSystemUsageOverviewReadModelOnChangesHandler.cs
+++ b/Core.DomainServices/SystemUsage/BuildItSystemUsageOverviewReadModelOnChangesHandler.cs
@@ -174,7 +174,6 @@ namespace Core.DomainServices.SystemUsage
             }
         }
 
-
         private void BuildFromSource(ItSystemUsageOverviewReadModel model, ItSystemUsage itSystemUsage)
         {
             _readModelUpdate.Apply(itSystemUsage, model);

--- a/Core.DomainServices/SystemUsage/ItSystemUsageOverviewReadModelUpdate.cs
+++ b/Core.DomainServices/SystemUsage/ItSystemUsageOverviewReadModelUpdate.cs
@@ -125,7 +125,6 @@ namespace Core.DomainServices.SystemUsage
                     destination.DataProcessingRegistrations.Add(dataProcessingRegistration);
                 }
             }
-            _dataProcessingRegistrationReadModelRepository.Save();
         }
 
         private void PatchRiskSupervisionDocumentation(ItSystemUsage source, ItSystemUsageOverviewReadModel destination)
@@ -173,7 +172,6 @@ namespace Core.DomainServices.SystemUsage
                     destination.ArchivePeriods.Add(archivePeriod);
                 }
             }
-            _archivePeriodReadModelRepository.Save();
         }
 
         private void PatchItProjects(ItSystemUsage source, ItSystemUsageOverviewReadModel destination)
@@ -206,7 +204,6 @@ namespace Core.DomainServices.SystemUsage
                     destination.ItProjects.Add(itProject);
                 }
             }
-            _itProjectReadModelRepository.Save();
         }
 
         private void PatchSensitiveDataLevels(ItSystemUsage source, ItSystemUsageOverviewReadModel destination)
@@ -234,7 +231,6 @@ namespace Core.DomainServices.SystemUsage
                     destination.SensitiveDataLevels.Add(sensitiveDataLevel);
                 }
             }
-            _sensitiveDataLevelRepository.Save();
         }
 
         private static void PatchMainContract(ItSystemUsage source, ItSystemUsageOverviewReadModel destination)
@@ -296,7 +292,6 @@ namespace Core.DomainServices.SystemUsage
                     destination.ItSystemTaskRefs.Add(taskRef);
                 }
             }
-            _taskRefRepository.Save();
         }
 
         private void PatchResponsibleOrganizationUnit(ItSystemUsage source, ItSystemUsageOverviewReadModel destination)
@@ -346,8 +341,6 @@ namespace Core.DomainServices.SystemUsage
                 assignment.UserFullName = GetUserFullName(incomingRight.User);
                 assignment.Email = incomingRight.User.Email;
             }
-
-            _roleAssignmentRepository.Save();
         }
 
         private void RemoveAssignments(ItSystemUsageOverviewReadModel destination, List<ItSystemUsageOverviewRoleAssignmentReadModel> assignmentsToBeRemoved)

--- a/Infrastructure.DataAccess/Infrastructure.DataAccess.csproj
+++ b/Infrastructure.DataAccess/Infrastructure.DataAccess.csproj
@@ -685,6 +685,7 @@
     <Compile Include="Migrations\Configuration.cs" />
     <Compile Include="Mapping\TerminationDeadlineTypeMap.cs" />
     <Compile Include="Services\DatabaseTransaction.cs" />
+    <Compile Include="Services\EntityFrameworkContextDatabaseControl.cs" />
     <Compile Include="Services\PocoTypeFromProxyResolver.cs" />
     <Compile Include="Services\WithinAmbienTransaction.cs" />
     <Compile Include="Services\TransactionManager.cs" />

--- a/Infrastructure.DataAccess/Services/EntityFrameworkContextDatabaseControl.cs
+++ b/Infrastructure.DataAccess/Services/EntityFrameworkContextDatabaseControl.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Infrastructure.Services.DataAccess;
+
+namespace Infrastructure.DataAccess.Services
+{
+    public class EntityFrameworkContextDatabaseControl : IDatabaseControl, IDisposable
+    {
+        private readonly KitosContext _kitosContext;
+
+        public EntityFrameworkContextDatabaseControl(KitosContext kitosContext)
+        {
+            _kitosContext = kitosContext;
+        }
+
+        public void Dispose()
+        {
+            _kitosContext?.Dispose();
+        }
+
+        public void SaveChanges()
+        {
+            _kitosContext.SaveChanges();
+        }
+    }
+}

--- a/Infrastructure.DataAccess/Services/TransactionManager.cs
+++ b/Infrastructure.DataAccess/Services/TransactionManager.cs
@@ -1,9 +1,10 @@
-﻿using System.Data;
+﻿using System;
+using System.Data;
 using Infrastructure.Services.DataAccess;
 
 namespace Infrastructure.DataAccess.Services
 {
-    public class TransactionManager : ITransactionManager
+    public class TransactionManager : ITransactionManager, IDisposable
     {
         private readonly KitosContext _context;
 
@@ -20,6 +21,11 @@ namespace Infrastructure.DataAccess.Services
                 return new WithinAmbienTransaction();
             }
             return new DatabaseTransaction(_context.Database.BeginTransaction());
+        }
+
+        public void Dispose()
+        {
+            _context?.Dispose();
         }
     }
 }

--- a/Infrastructure.Services/DataAccess/IDatabaseControl.cs
+++ b/Infrastructure.Services/DataAccess/IDatabaseControl.cs
@@ -1,0 +1,7 @@
+﻿namespace Infrastructure.Services.DataAccess
+{
+    public interface IDatabaseControl
+    {
+        void SaveChanges();
+    }
+}

--- a/Infrastructure.Services/Infrastructure.Services.csproj
+++ b/Infrastructure.Services/Infrastructure.Services.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Configuration\KitosUrl.cs" />
     <Compile Include="Cryptography\CryptoService.cs" />
     <Compile Include="Cryptography\ICryptoService.cs" />
+    <Compile Include="DataAccess\IDatabaseControl.cs" />
     <Compile Include="DataAccess\IDatabaseTransaction.cs" />
     <Compile Include="DataAccess\IEntityTypeResolver.cs" />
     <Compile Include="DataAccess\ITransactionManager.cs" />

--- a/Presentation.Web/Hangfire/KeepReadModelsInSyncProcess.cs
+++ b/Presentation.Web/Hangfire/KeepReadModelsInSyncProcess.cs
@@ -27,7 +27,7 @@ namespace Presentation.Web.Hangfire
                 ProcessItSystemUsageModule(backgroundJobLauncher, combinedTokenSource);
             }
 
-            CoolDown(combinedTokenSource);
+            CoolDown();
         }
 
         private static void ProcessItSystemUsageModule(IBackgroundJobLauncher backgroundJobLauncher,
@@ -44,14 +44,9 @@ namespace Presentation.Web.Hangfire
             backgroundJobLauncher.LaunchUpdateDataProcessingRegistrationReadModels(combinedTokenSource.Token).Wait(CancellationToken.None);
         }
 
-        private static void CoolDown(CancellationTokenSource combinedTokenSource)
+        private static void CoolDown()
         {
-            var secondsPassed = 0;
-            do
-            {
-                Thread.Sleep(TimeSpan.FromSeconds(1));
-                secondsPassed++;
-            } while (secondsPassed < 3 && combinedTokenSource.IsCancellationRequested == false);
+            Thread.Sleep(TimeSpan.FromSeconds(1));
         }
     }
 }

--- a/Presentation.Web/Ninject/KernelBuilder.cs
+++ b/Presentation.Web/Ninject/KernelBuilder.cs
@@ -341,6 +341,7 @@ namespace Presentation.Web.Ninject
             kernel.Bind<IItSystemRepository>().To<ItSystemRepository>().InCommandScope(Mode);
             kernel.Bind<IItContractRepository>().To<ItContractRepository>().InCommandScope(Mode);
             kernel.Bind<ITransactionManager>().To<TransactionManager>().InCommandScope(Mode);
+            kernel.Bind<IDatabaseControl>().To<EntityFrameworkContextDatabaseControl>().InCommandScope(Mode);
             kernel.Bind<IItSystemUsageRepository>().To<ItSystemUsageRepository>().InCommandScope(Mode);
             kernel.Bind<IItProjectRepository>().To<ItProjectRepository>().InCommandScope(Mode);
             kernel.Bind<IInterfaceRepository>().To<InterfaceRepository>().InCommandScope(Mode);

--- a/Presentation.Web/Web.config
+++ b/Presentation.Web/Web.config
@@ -15,7 +15,7 @@
   <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>
-    <add name="KitosContext" connectionString="Server=.\SQLEXPRESS;Integrated Security=true;Initial Catalog=KitosProd1;MultipleActiveResultSets=True" providerName="System.Data.SqlClient" />
+    <add name="KitosContext" connectionString="Server=.\SQLEXPRESS;Integrated Security=true;Initial Catalog=Kitos;MultipleActiveResultSets=True" providerName="System.Data.SqlClient" />
     <add name="kitos_HangfireDB" connectionString="Server=.\SQLEXPRESS;Integrated Security=true;Initial Catalog=kitos_HangfireDB;MultipleActiveResultSets=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>

--- a/Presentation.Web/Web.config
+++ b/Presentation.Web/Web.config
@@ -15,7 +15,7 @@
   <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>
-    <add name="KitosContext" connectionString="Server=.\SQLEXPRESS;Integrated Security=true;Initial Catalog=Kitos;MultipleActiveResultSets=True" providerName="System.Data.SqlClient" />
+    <add name="KitosContext" connectionString="Server=.\SQLEXPRESS;Integrated Security=true;Initial Catalog=KitosProd1;MultipleActiveResultSets=True" providerName="System.Data.SqlClient" />
     <add name="kitos_HangfireDB" connectionString="Server=.\SQLEXPRESS;Integrated Security=true;Initial Catalog=kitos_HangfireDB;MultipleActiveResultSets=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>

--- a/Tests.Integration.Presentation.Web/GDPR/DataProcessingRegistrationReadModelsTest.cs
+++ b/Tests.Integration.Presentation.Web/GDPR/DataProcessingRegistrationReadModelsTest.cs
@@ -77,14 +77,14 @@ namespace Tests.Integration.Presentation.Web.GDPR
             var dataProcessor = await OrganizationHelper.CreateOrganizationAsync(organizationId, dpName, "22334455", OrganizationTypeKeys.Virksomhed, AccessModifier.Public);
             var subDataProcessor = await OrganizationHelper.CreateOrganizationAsync(organizationId, subDpName, "22314455", OrganizationTypeKeys.Virksomhed, AccessModifier.Public);
             var registration = await DataProcessingRegistrationHelper.CreateAsync(organizationId, name);
-            var businessRoleDtos = await DataProcessingRegistrationHelper.GetAvailableRolesAsync(registration.Id);
-            var role = businessRoleDtos.First();
-            var availableUsers = await DataProcessingRegistrationHelper.GetAvailableUsersAsync(registration.Id, role.Id);
-            var user = availableUsers.First();
             await DataProcessingRegistrationHelper.SendChangeOversightIntervalOptionRequestAsync(registration.Id, oversightInterval);
 
             await DataProcessingRegistrationHelper.SendChangeIsOversightCompletedRequestAsync(registration.Id, oversightCompleted);
 
+            var businessRoleDtos = await DataProcessingRegistrationHelper.GetAvailableRolesAsync(registration.Id);
+            var role = businessRoleDtos.First();
+            var availableUsers = await DataProcessingRegistrationHelper.GetAvailableUsersAsync(registration.Id, role.Id);
+            var user = availableUsers.First();
             _testOutputHelper.WriteLine($"Attempting to assign user {user.Id}:{user.Email} as role {role.Id}:{role.Name} in dpr {registration.Id}:{registration.Name}");
             using var response = await DataProcessingRegistrationHelper.SendAssignRoleRequestAsync(registration.Id, role.Id, user.Id);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/Tests.Integration.Presentation.Web/GDPR/DataProcessingRegistrationReadModelsTest.cs
+++ b/Tests.Integration.Presentation.Web/GDPR/DataProcessingRegistrationReadModelsTest.cs
@@ -13,11 +13,19 @@ using Tests.Integration.Presentation.Web.Tools;
 using Tests.Toolkit.Patterns;
 using Xunit;
 using System.Threading;
+using Xunit.Abstractions;
 
 namespace Tests.Integration.Presentation.Web.GDPR
 {
     public class DataProcessingRegistrationReadModelsTest : WithAutoFixture
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public DataProcessingRegistrationReadModelsTest(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         [Fact]
         public async Task Can_Query_And_Page_ReadModels()
         {
@@ -73,12 +81,11 @@ namespace Tests.Integration.Presentation.Web.GDPR
             var role = businessRoleDtos.First();
             var availableUsers = await DataProcessingRegistrationHelper.GetAvailableUsersAsync(registration.Id, role.Id);
             var user = availableUsers.First();
-            await DataProcessingRegistrationHelper.SendChangeOversightIntervalOptionRequestAsync(registration.Id,
-                oversightInterval);
+            await DataProcessingRegistrationHelper.SendChangeOversightIntervalOptionRequestAsync(registration.Id, oversightInterval);
 
-            await DataProcessingRegistrationHelper.SendChangeIsOversightCompletedRequestAsync(registration.Id,
-                oversightCompleted);
+            await DataProcessingRegistrationHelper.SendChangeIsOversightCompletedRequestAsync(registration.Id, oversightCompleted);
 
+            _testOutputHelper.WriteLine($"Attempting to assign user {user.Id}:{user.Email} as role {role.Id}:{role.Name} in dpr {registration.Id}:{registration.Name}");
             using var response = await DataProcessingRegistrationHelper.SendAssignRoleRequestAsync(registration.Id, role.Id, user.Id);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 


### PR DESCRIPTION
- [x] Reduced batch size in each job. Large sessions perform very badly
- [x] Reduced cooldown to 1 second in main process
- [x] Reduces calls to saveChanges - it should only be called once per unit of work. Otherwise performance is degraded substantially