### PR TITLE
Added migration for advicetype

### DIFF
--- a/Infrastructure.DataAccess/Infrastructure.DataAccess.csproj
+++ b/Infrastructure.DataAccess/Infrastructure.DataAccess.csproj
@@ -1184,6 +1184,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Migrations\SQLScripts\Migration_DPR_LatestOversightDate.sql" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Migrations\SQLScripts\Migrate_Advice_Scheduling_To_AdviceType.sql" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/Infrastructure.DataAccess/Migrations/202105171042142_Added_Advicetype_To_Advice.cs
+++ b/Infrastructure.DataAccess/Migrations/202105171042142_Added_Advicetype_To_Advice.cs
@@ -10,6 +10,7 @@
         {
             SqlResource(SqlMigrationScriptRepository.GetResourceName("FixAdviceIsActive.sql"));
             AddColumn("dbo.Advice", "AdviceType", c => c.Int(nullable: false));
+            SqlResource(SqlMigrationScriptRepository.GetResourceName("Migrate_Advice_Scheduling_To_AdviceType.sql"));
         }
         
         public override void Down()

--- a/Infrastructure.DataAccess/Migrations/SQLScripts/Migrate_Advice_Scheduling_To_AdviceType.sql
+++ b/Infrastructure.DataAccess/Migrations/SQLScripts/Migrate_Advice_Scheduling_To_AdviceType.sql
@@ -1,5 +1,7 @@
 ﻿/*
 Content:
+    Some advices with scheduling IS NULL are setup in hangfire with daily recurring job. These are first changed to have scheduling=2 (day)
+
     Updates existing Advice with AdviceType based on previous scheduling value:
     - All advices with scheduling=0 (Immediate) get AdviceType=0 (Immediate)
     - All advices with scheduling!=0 get AdviceType=1 (Repeat)
@@ -7,6 +9,10 @@ Content:
 */
 
 BEGIN
+
+    UPDATE [kitos].[dbo].[Advice]
+    SET Scheduling=2
+    WHERE Id = 1145 OR Id = 1146 OR Id = 1192 OR Id = 1213 OR Id = 1882
     
     UPDATE [kitos].[dbo].[Advice]
     SET AdviceType=0

--- a/Infrastructure.DataAccess/Migrations/SQLScripts/Migrate_Advice_Scheduling_To_AdviceType.sql
+++ b/Infrastructure.DataAccess/Migrations/SQLScripts/Migrate_Advice_Scheduling_To_AdviceType.sql
@@ -1,0 +1,23 @@
+﻿/*
+Content:
+    Updates existing Advice with AdviceType based on previous scheduling value:
+    - All advices with scheduling=0 (Immediate) get AdviceType=0 (Immediate)
+    - All advices with scheduling!=0 get AdviceType=1 (Repeat)
+    - All advices with scheduling IS NULL get AdviceType=0 (Immediate)
+*/
+
+BEGIN
+    
+    UPDATE [kitos].[dbo].[Advice]
+    SET AdviceType=0
+    WHERE Scheduling=0
+
+    UPDATE [kitos].[dbo].[Advice]
+    SET AdviceType=1
+    WHERE Scheduling!=0
+
+    UPDATE [kitos].[dbo].[Advice]
+    SET AdviceType=0
+    WHERE Scheduling IS NULL
+
+END


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39791946/118972365-c6ef9d80-b970-11eb-9a4e-e5649c315e08.png)

Der er umiddelbart 5 advis som har scheduling = null, men som er oprettet som recurring job i hangfire 