### PR TITLE
Bugfix/kitosudv 4549

### DIFF
--- a/Presentation.Web/Controllers/API/V1/ExtendedApiController.cs
+++ b/Presentation.Web/Controllers/API/V1/ExtendedApiController.cs
@@ -14,7 +14,6 @@ using Presentation.Web.Helpers;
 using Presentation.Web.Models.API.V1;
 using System.Web.Http.ModelBinding;
 using Core.Abstractions.Types;
-using Core.ApplicationServices.Authorization;
 
 namespace Presentation.Web.Controllers.API.V1
 {
@@ -26,10 +25,6 @@ namespace Presentation.Web.Controllers.API.V1
 
         [Inject]
         public IMapper Mapper { get; set; }
-
-        [Inject]
-        public IOrganizationalUserContext UserContext { get; set; }
-        protected int UserId => UserContext.UserId;
 
         protected HttpResponseMessage LogError(Exception exp, [CallerMemberName] string memberName = "")
         {

--- a/Presentation.Web/Controllers/API/V1/OrganizationUnitController.cs
+++ b/Presentation.Web/Controllers/API/V1/OrganizationUnitController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Web.Http;
+using Core.ApplicationServices.Authorization;
 using Core.ApplicationServices.Organizations;
 using Core.DomainModel.Extensions;
 using Core.DomainModel.Organization;
@@ -20,15 +21,18 @@ namespace Presentation.Web.Controllers.API.V1
     {
         private readonly IOrgUnitService _orgUnitService;
         private readonly IOrganizationUnitService _organizationUnitService;
+        private readonly IOrganizationalUserContext _userContext;
 
         public OrganizationUnitController(
             IGenericRepository<OrganizationUnit> repository,
             IOrgUnitService orgUnitService,
-            IOrganizationUnitService organizationUnitService)
+            IOrganizationUnitService organizationUnitService,
+            IOrganizationalUserContext userContext)
             : base(repository)
         {
             _orgUnitService = orgUnitService;
             _organizationUnitService = organizationUnitService;
+            _userContext = userContext;
         }
 
         public HttpResponseMessage Post(OrgUnitDTO dto) => base.Post(dto.OrganizationId, dto);
@@ -54,7 +58,7 @@ namespace Presentation.Web.Controllers.API.V1
                 if (GetOrganizationReadAccessLevel(organizationId) < OrganizationDataReadAccessLevel.Public)
                     return Forbidden();
 
-                var userId = UserId;
+                var userId = _userContext.UserId;
                 var orgUnits = Repository
                     .Get(x => x.Rights.Any(y => y.UserId == userId) && x.OrganizationId == organizationId)
                     .SelectMany(unit => unit.FlattenHierarchy())

--- a/Presentation.Web/Controllers/API/V1/UserController.cs
+++ b/Presentation.Web/Controllers/API/V1/UserController.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Web;
 using System.Web.Http;
 using Core.ApplicationServices;
+using Core.ApplicationServices.Authorization;
 using Core.ApplicationServices.Authorization.Permissions;
 using Core.ApplicationServices.Model.RightsHolder;
 using Core.ApplicationServices.Organizations;
@@ -30,17 +31,20 @@ namespace Presentation.Web.Controllers.API.V1
         private readonly IUserService _userService;
         private readonly IOrganizationService _organizationService;
         private readonly IUserRightsService _userRightsService;
+        private readonly IOrganizationalUserContext _userContext;
 
         public UserController(
             IGenericRepository<User> repository,
             IUserService userService,
             IOrganizationService organizationService,
-            IUserRightsService userRightsService)
+            IUserRightsService userRightsService,
+            IOrganizationalUserContext userContext)
             : base(repository)
         {
             _userService = userService;
             _organizationService = organizationService;
             _userRightsService = userRightsService;
+            _userContext = userContext;
         }
 
         [NonAction]
@@ -158,7 +162,7 @@ namespace Presentation.Web.Controllers.API.V1
         {
             try
             {
-                var user = Repository.GetByKey(UserId);
+                var user = Repository.GetByKey(_userContext.UserId);
                 if (user == null)
                     return NotFound();
 


### PR DESCRIPTION
Issue was caused by
- Introduction of UserContext in BaseApiController which prevented UserContext in the base class from being set.

Removed
- UserId as well as UserContext from ExtendedApiController

Changed
- Dependers of the old property to explicitly use the usercontext directly

## KITOS Pull request template
The following procedure dictates the steps needed before a Pull request can be merged into master.

- [x] **Implement**: 
      *All requirements are implemented and unit tests are green*
      
- [x] **Merge master into branch / rebase with master**: 
      *Make sure you are testing your changes and how they co-exist with the latest version of master*
      
- [x] **Green on integration**: 
      *All integration tests are green on integration*
      
- [x] **Request review**: 
      *Tag whomever you wish to review your code*
      
- [ ] **Review completed**: 
      *Reviewer ticks this box when review comments have been submitted*
      
- [ ] **Changes**: 
      *PR owner and reviewer agrees on which changes must be made and the changes are committed.*
      
- [ ] **Merge master into branch / rebase with master**: 
      *Make sure you are testing your changes and how they co-exist with the latest version of master*
      
- [ ] **Green on integration**: 
      *All integration tests are green on integration*
