### PR TITLE
Authorizing modification of master data roles by root org

### DIFF
--- a/Core.ApplicationServices/Organizations/Write/OrganizationWriteService.cs
+++ b/Core.ApplicationServices/Organizations/Write/OrganizationWriteService.cs
@@ -176,9 +176,6 @@ public class OrganizationWriteService : IOrganizationWriteService{
     private Result<OrganizationMasterDataRoles, OperationError> AuthorizeAndPerformMasterDataRolesUpsert(Guid organizationUuid,
         OrganizationMasterDataRolesUpdateParameters updateParameters)
     {
-        var organizationDbIdMaybe = _identityResolver.ResolveDbId<Organization>(organizationUuid);
-        if (organizationDbIdMaybe.IsNone) return new OperationError(OperationFailure.BadInput);
-        var orgId = organizationDbIdMaybe.Value;
         var organizationResult = _organizationService.GetOrganization(organizationUuid);
         if (organizationResult.Failed) return new OperationError(OperationFailure.BadInput);
 

--- a/Core.ApplicationServices/Organizations/Write/OrganizationWriteService.cs
+++ b/Core.ApplicationServices/Organizations/Write/OrganizationWriteService.cs
@@ -177,7 +177,7 @@ public class OrganizationWriteService : IOrganizationWriteService{
         OrganizationMasterDataRolesUpdateParameters updateParameters)
     {
         var organizationResult = _organizationService.GetOrganization(organizationUuid);
-        if (organizationResult.Failed) return new OperationError(OperationFailure.BadInput);
+        if (organizationResult.Failed) return organizationResult.Error;
 
         var organization = organizationResult.Value;
 

--- a/Core.ApplicationServices/Organizations/Write/OrganizationWriteService.cs
+++ b/Core.ApplicationServices/Organizations/Write/OrganizationWriteService.cs
@@ -181,15 +181,15 @@ public class OrganizationWriteService : IOrganizationWriteService{
         var orgId = organizationDbIdMaybe.Value;
 
         var modifiedContactPersonResult =
-            AuthorizeModificationAndUpsertContactPerson(orgId,
+            UpsertContactPerson(orgId,
                 updateParameters.ContactPerson);
         if (modifiedContactPersonResult.Failed) return modifiedContactPersonResult.Error;
 
         var modifiedDataResponsibleResult =
-            AuthorizeModificationAndUpsertDataResponsible(orgId, updateParameters.DataResponsible);
+            UpsertDataResponsible(orgId, updateParameters.DataResponsible);
         if (modifiedDataResponsibleResult.Failed) return modifiedDataResponsibleResult.Error;
 
-        var modifiedDataProtectionAdvisorResult = AuthorizeModificationAndUpsertDataProtectionAdvisor(orgId,
+        var modifiedDataProtectionAdvisorResult = UpsertDataProtectionAdvisor(orgId,
             updateParameters.DataProtectionAdvisor);
         if (modifiedDataProtectionAdvisorResult.Failed) return modifiedDataProtectionAdvisorResult.Error;
 
@@ -202,23 +202,18 @@ public class OrganizationWriteService : IOrganizationWriteService{
         };
     }
 
-    private Result<ContactPerson, OperationError> AuthorizeModificationAndUpsertContactPerson(
+    private Result<ContactPerson, OperationError> UpsertContactPerson(
         int organizationId, Maybe<ContactPersonUpdateParameters> parameters)
     {
-        return UpsertContactPerson(organizationId)
-            .Bind(ValidateModifyContactPerson)
+        return UpsertContactPersonByOrganizationId(organizationId)
             .Bind(contactPerson => ModifyContactPerson(contactPerson, parameters));
     }
     
-    private Result<ContactPerson, OperationError> UpsertContactPerson(int organizationId)
+    private Result<ContactPerson, OperationError> UpsertContactPersonByOrganizationId(int organizationId)
         {
-            return _organizationService.GetContactPerson(organizationId)
-                .Match(contactPerson => contactPerson,
-                    () => AuthorizeCreationAndCreateContactPerson(organizationId));
+         return _organizationService.GetContactPerson(organizationId).Match(contactPerson => contactPerson,
+            () => AuthorizeCreationAndCreateContactPerson(organizationId));
         }
-
-    private Result<ContactPerson, OperationError> ValidateModifyContactPerson(ContactPerson contactPerson) =>
-        _authorizationContext.AllowModify(contactPerson) ? contactPerson : new OperationError(OperationFailure.Forbidden);
 
     private Result<ContactPerson, OperationError> AuthorizeCreationAndCreateContactPerson(int orgId)
     {
@@ -263,18 +258,14 @@ public class OrganizationWriteService : IOrganizationWriteService{
         return contactPerson;
     }
 
-    private Result<DataResponsible, OperationError> AuthorizeModificationAndUpsertDataResponsible(
+    private Result<DataResponsible, OperationError> UpsertDataResponsible(
         int organizationId, Maybe<DataResponsibleUpdateParameters> parameters)
     {
-        return UpsertDataResponsible(organizationId)
-            .Bind(ValidateModifyDataResponsible)
+        return UpsertDataResponsibleByOrganizationId(organizationId)
             .Bind(dataResponsible => ModifyDataResponsible(dataResponsible, parameters));
     }
-    private Result<DataResponsible, OperationError> ValidateModifyDataResponsible(DataResponsible dataResponsible) =>
-        _authorizationContext.AllowModify(dataResponsible) ? dataResponsible : new OperationError(OperationFailure.Forbidden);
 
-
-    private Result<DataResponsible, OperationError> UpsertDataResponsible(int orgId)
+    private Result<DataResponsible, OperationError> UpsertDataResponsibleByOrganizationId(int orgId)
     {
         return _organizationService.GetDataResponsible(orgId)
             .Match(dr => dr,
@@ -328,15 +319,14 @@ public class OrganizationWriteService : IOrganizationWriteService{
         return dataResponsible;
     }
 
-    private Result<DataProtectionAdvisor, OperationError> AuthorizeModificationAndUpsertDataProtectionAdvisor(
+    private Result<DataProtectionAdvisor, OperationError> UpsertDataProtectionAdvisor(
         int organizationId, Maybe<DataProtectionAdvisorUpdateParameters> parameters)
     {
-        return UpsertDataProtectionAdvisor(organizationId)
-            .Bind(ValidateModifyDataProtectionAdvisor)
+        return UpsertDataProtectionAdvisorByOrganizationId(organizationId)
             .Bind(dataProtectionAdvisor => ModifyDataProtectionAdvisor(dataProtectionAdvisor, parameters));
     }
 
-    private Result<DataProtectionAdvisor, OperationError> UpsertDataProtectionAdvisor(int orgId)
+    private Result<DataProtectionAdvisor, OperationError> UpsertDataProtectionAdvisorByOrganizationId(int orgId)
     {
         return _organizationService.GetDataProtectionAdvisor(orgId)
             .Match(dataProtectionAdvisor => dataProtectionAdvisor,
@@ -357,9 +347,6 @@ public class OrganizationWriteService : IOrganizationWriteService{
         _dataProtectionAdvisorRepository.Save();
         return dataProtectionAdvisor;
     }
-
-    private Result<DataProtectionAdvisor, OperationError> ValidateModifyDataProtectionAdvisor(DataProtectionAdvisor dataProtectionAdvisor) =>
-        _authorizationContext.AllowModify(dataProtectionAdvisor) ? dataProtectionAdvisor : new OperationError(OperationFailure.Forbidden);
 
     private Result<DataProtectionAdvisor, OperationError> ModifyDataProtectionAdvisor(DataProtectionAdvisor dataProtectionAdvisor, Maybe<DataProtectionAdvisorUpdateParameters> parametersMaybe)
     {

--- a/Core.ApplicationServices/Organizations/Write/OrganizationWriteService.cs
+++ b/Core.ApplicationServices/Organizations/Write/OrganizationWriteService.cs
@@ -192,7 +192,7 @@ public class OrganizationWriteService : IOrganizationWriteService{
             AuthorizeModificationAndUpsertDataResponsible(organization, updateParameters.DataResponsible);
         if (modifiedDataResponsibleResult.Failed) return modifiedDataResponsibleResult.Error;
 
-        var modifiedDataProtectionAdvisorResult = AuthorizeModificationAndUpsertDataProtectionAdvisor(orgId,
+        var modifiedDataProtectionAdvisorResult = AuthorizeModificationAndUpsertDataProtectionAdvisor(organization,
             updateParameters.DataProtectionAdvisor);
         if (modifiedDataProtectionAdvisorResult.Failed) return modifiedDataProtectionAdvisorResult.Error;
 
@@ -332,10 +332,10 @@ public class OrganizationWriteService : IOrganizationWriteService{
     }
 
     private Result<DataProtectionAdvisor, OperationError> AuthorizeModificationAndUpsertDataProtectionAdvisor(
-        int organizationId, Maybe<DataProtectionAdvisorUpdateParameters> parameters)
+        Organization organization, Maybe<DataProtectionAdvisorUpdateParameters> parameters)
     {
-        return UpsertDataProtectionAdvisor(organizationId)
-            .Bind(ValidateModifyDataProtectionAdvisor)
+        return UpsertDataProtectionAdvisor(organization.Id)
+            .Bind(dataProtectionAdvisor => ValidateModifyDataProtectionAdvisorByRootOrganization(dataProtectionAdvisor, organization))
             .Bind(dataProtectionAdvisor => ModifyDataProtectionAdvisor(dataProtectionAdvisor, parameters));
     }
 
@@ -361,8 +361,8 @@ public class OrganizationWriteService : IOrganizationWriteService{
         return dataProtectionAdvisor;
     }
 
-    private Result<DataProtectionAdvisor, OperationError> ValidateModifyDataProtectionAdvisor(DataProtectionAdvisor dataProtectionAdvisor) =>
-        _authorizationContext.AllowModify(dataProtectionAdvisor) ? dataProtectionAdvisor : new OperationError(OperationFailure.Forbidden);
+    private Result<DataProtectionAdvisor, OperationError> ValidateModifyDataProtectionAdvisorByRootOrganization(DataProtectionAdvisor dataProtectionAdvisor, Organization organization) =>
+        _authorizationContext.AllowModify(organization) ? dataProtectionAdvisor : new OperationError(OperationFailure.Forbidden);
 
     private Result<DataProtectionAdvisor, OperationError> ModifyDataProtectionAdvisor(DataProtectionAdvisor dataProtectionAdvisor, Maybe<DataProtectionAdvisorUpdateParameters> parametersMaybe)
     {

--- a/Core.ApplicationServices/Organizations/Write/OrganizationWriteService.cs
+++ b/Core.ApplicationServices/Organizations/Write/OrganizationWriteService.cs
@@ -181,15 +181,15 @@ public class OrganizationWriteService : IOrganizationWriteService{
         var orgId = organizationDbIdMaybe.Value;
 
         var modifiedContactPersonResult =
-            UpsertContactPerson(orgId,
+            AuthorizeModificationAndUpsertContactPerson(orgId,
                 updateParameters.ContactPerson);
         if (modifiedContactPersonResult.Failed) return modifiedContactPersonResult.Error;
 
         var modifiedDataResponsibleResult =
-            UpsertDataResponsible(orgId, updateParameters.DataResponsible);
+            AuthorizeModificationAndUpsertDataResponsible(orgId, updateParameters.DataResponsible);
         if (modifiedDataResponsibleResult.Failed) return modifiedDataResponsibleResult.Error;
 
-        var modifiedDataProtectionAdvisorResult = UpsertDataProtectionAdvisor(orgId,
+        var modifiedDataProtectionAdvisorResult = AuthorizeModificationAndUpsertDataProtectionAdvisor(orgId,
             updateParameters.DataProtectionAdvisor);
         if (modifiedDataProtectionAdvisorResult.Failed) return modifiedDataProtectionAdvisorResult.Error;
 
@@ -202,18 +202,23 @@ public class OrganizationWriteService : IOrganizationWriteService{
         };
     }
 
-    private Result<ContactPerson, OperationError> UpsertContactPerson(
+    private Result<ContactPerson, OperationError> AuthorizeModificationAndUpsertContactPerson(
         int organizationId, Maybe<ContactPersonUpdateParameters> parameters)
     {
-        return UpsertContactPersonByOrganizationId(organizationId)
+        return UpsertContactPerson(organizationId)
+            .Bind(ValidateModifyContactPerson)
             .Bind(contactPerson => ModifyContactPerson(contactPerson, parameters));
     }
     
-    private Result<ContactPerson, OperationError> UpsertContactPersonByOrganizationId(int organizationId)
+    private Result<ContactPerson, OperationError> UpsertContactPerson(int organizationId)
         {
-         return _organizationService.GetContactPerson(organizationId).Match(contactPerson => contactPerson,
-            () => AuthorizeCreationAndCreateContactPerson(organizationId));
+            return _organizationService.GetContactPerson(organizationId)
+                .Match(contactPerson => contactPerson,
+                    () => AuthorizeCreationAndCreateContactPerson(organizationId));
         }
+
+    private Result<ContactPerson, OperationError> ValidateModifyContactPerson(ContactPerson contactPerson) =>
+        _authorizationContext.AllowModify(contactPerson) ? contactPerson : new OperationError(OperationFailure.Forbidden);
 
     private Result<ContactPerson, OperationError> AuthorizeCreationAndCreateContactPerson(int orgId)
     {
@@ -258,14 +263,18 @@ public class OrganizationWriteService : IOrganizationWriteService{
         return contactPerson;
     }
 
-    private Result<DataResponsible, OperationError> UpsertDataResponsible(
+    private Result<DataResponsible, OperationError> AuthorizeModificationAndUpsertDataResponsible(
         int organizationId, Maybe<DataResponsibleUpdateParameters> parameters)
     {
-        return UpsertDataResponsibleByOrganizationId(organizationId)
+        return UpsertDataResponsible(organizationId)
+            .Bind(ValidateModifyDataResponsible)
             .Bind(dataResponsible => ModifyDataResponsible(dataResponsible, parameters));
     }
+    private Result<DataResponsible, OperationError> ValidateModifyDataResponsible(DataResponsible dataResponsible) =>
+        _authorizationContext.AllowModify(dataResponsible) ? dataResponsible : new OperationError(OperationFailure.Forbidden);
 
-    private Result<DataResponsible, OperationError> UpsertDataResponsibleByOrganizationId(int orgId)
+
+    private Result<DataResponsible, OperationError> UpsertDataResponsible(int orgId)
     {
         return _organizationService.GetDataResponsible(orgId)
             .Match(dr => dr,
@@ -319,14 +328,15 @@ public class OrganizationWriteService : IOrganizationWriteService{
         return dataResponsible;
     }
 
-    private Result<DataProtectionAdvisor, OperationError> UpsertDataProtectionAdvisor(
+    private Result<DataProtectionAdvisor, OperationError> AuthorizeModificationAndUpsertDataProtectionAdvisor(
         int organizationId, Maybe<DataProtectionAdvisorUpdateParameters> parameters)
     {
-        return UpsertDataProtectionAdvisorByOrganizationId(organizationId)
+        return UpsertDataProtectionAdvisor(organizationId)
+            .Bind(ValidateModifyDataProtectionAdvisor)
             .Bind(dataProtectionAdvisor => ModifyDataProtectionAdvisor(dataProtectionAdvisor, parameters));
     }
 
-    private Result<DataProtectionAdvisor, OperationError> UpsertDataProtectionAdvisorByOrganizationId(int orgId)
+    private Result<DataProtectionAdvisor, OperationError> UpsertDataProtectionAdvisor(int orgId)
     {
         return _organizationService.GetDataProtectionAdvisor(orgId)
             .Match(dataProtectionAdvisor => dataProtectionAdvisor,
@@ -347,6 +357,9 @@ public class OrganizationWriteService : IOrganizationWriteService{
         _dataProtectionAdvisorRepository.Save();
         return dataProtectionAdvisor;
     }
+
+    private Result<DataProtectionAdvisor, OperationError> ValidateModifyDataProtectionAdvisor(DataProtectionAdvisor dataProtectionAdvisor) =>
+        _authorizationContext.AllowModify(dataProtectionAdvisor) ? dataProtectionAdvisor : new OperationError(OperationFailure.Forbidden);
 
     private Result<DataProtectionAdvisor, OperationError> ModifyDataProtectionAdvisor(DataProtectionAdvisor dataProtectionAdvisor, Maybe<DataProtectionAdvisorUpdateParameters> parametersMaybe)
     {

--- a/Tests.Integration.Presentation.Web/Organizations/V2/OrganizationInternalApiV2Test.cs
+++ b/Tests.Integration.Presentation.Web/Organizations/V2/OrganizationInternalApiV2Test.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Reflection;
 using System.Threading.Tasks;
 using Core.DomainModel;
 using Core.DomainModel.Organization;
@@ -10,7 +9,6 @@ using Presentation.Web.Models.API.V1;
 using Presentation.Web.Models.API.V2.Internal.Request.Organizations;
 using Presentation.Web.Models.API.V2.Internal.Response.Organizations;
 using Presentation.Web.Models.API.V2.Response.Organization;
-using Presentation.Web.Models.API.V2.Response.Shared;
 using Tests.Integration.Presentation.Web.Tools;
 using Tests.Integration.Presentation.Web.Tools.Extensions;
 using Tests.Integration.Presentation.Web.Tools.External;

--- a/Tests.Unit.Presentation.Web/Services/OrganizationWriteServiceTest.cs
+++ b/Tests.Unit.Presentation.Web/Services/OrganizationWriteServiceTest.cs
@@ -175,6 +175,72 @@ namespace Tests.Unit.Presentation.Web.Services
             Assert.Equal(OperationFailure.BadInput, error.FailureType);
         }
 
+        [Fact]
+        public void Update_Master_Data_Roles_Returns_Forbidden_If_Unauthorized_To_Modify_Data_Responsible()
+        {
+            var org = GetOrgAndSetupForVerifyUnauthorized();
+            var orgId = org.Id;
+            var updateParameters = SetupUpdateMasterDataRoles(orgId);
+            _identityResolver.Setup(_ =>
+                    _.ResolveDbId<Organization>(org.Uuid))
+                .Returns(orgId);
+            _authorizationContext.Setup(_ =>
+                    _.AllowModify(It.IsAny<ContactPerson>()))
+                .Returns(true);
+            _authorizationContext.Setup(_ =>
+                    _.AllowModify(It.IsAny<DataResponsible>()))
+                .Returns(false);
+            _authorizationContext.Setup(_ =>
+                    _.AllowModify(It.IsAny<DataProtectionAdvisor>()))
+                .Returns(true);
+
+            var result =
+                _sut.UpsertOrganizationMasterDataRoles(org.Uuid, updateParameters);
+
+            Assert.True(result.Failed);
+            var error = result.Error;
+            Assert.Equal(OperationFailure.Forbidden, error.FailureType);
+        }
+
+        [Fact]
+        public void Update_Master_Data_Roles_Returns_Forbidden_If_Unauthorized_To_Modify_Contact_Person()
+        {
+            var org = GetOrgAndSetupForVerifyUnauthorized();
+            var orgId = org.Id;
+            var updateParameters = SetupUpdateMasterDataRoles(orgId);
+            _authorizationContext.Setup(_ =>
+                    _.AllowModify(It.IsAny<ContactPerson>()))
+                .Returns(false);
+            _authorizationContext.Setup(_ =>
+                    _.AllowModify(It.IsAny<DataResponsible>()))
+                .Returns(true);
+            _authorizationContext.Setup(_ =>
+                    _.AllowModify(It.IsAny<DataProtectionAdvisor>()))
+                .Returns(true);
+
+            var result =
+                _sut.UpsertOrganizationMasterDataRoles(org.Uuid, updateParameters);
+
+            Assert.True(result.Failed);
+            var error = result.Error;
+            Assert.Equal(OperationFailure.Forbidden, error.FailureType);
+        }
+
+        [Fact]
+        public void Update_Master_Data_Roles_Returns_Forbidden_If_Unauthorized_To_Modify_Data_Protection_Advisor()
+        {
+            var org = GetOrgAndSetupForVerifyUnauthorized();
+            var orgId = org.Id;
+            var updateParameters = SetupUpdateMasterDataRoles(orgId);
+            
+            var result =
+                _sut.UpsertOrganizationMasterDataRoles(org.Uuid, updateParameters);
+
+            Assert.True(result.Failed);
+            var error = result.Error;
+            Assert.Equal(OperationFailure.Forbidden, error.FailureType);
+        }
+
         public Organization GetOrgAndSetupForVerifyUnauthorized()
         {
             var org = CreateOrganization();

--- a/Tests.Unit.Presentation.Web/Services/OrganizationWriteServiceTest.cs
+++ b/Tests.Unit.Presentation.Web/Services/OrganizationWriteServiceTest.cs
@@ -227,14 +227,9 @@ namespace Tests.Unit.Presentation.Web.Services
                     _.ResolveDbId<Organization>(org.Uuid))
                 .Returns(expectedContactPerson.OrganizationId);
 
+            _organizationService.Setup(_ => _.GetOrganization(org.Uuid, null)).Returns(org);
             _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<ContactPerson>()))
-                .Returns(true);
-            _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<DataResponsible>()))
-                .Returns(true);
-            _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<DataProtectionAdvisor>()))
+                    _.AllowModify(It.IsAny<Organization>()))
                 .Returns(true);
             _organizationService.Setup(_ => _.GetContactPerson(orgId)).Returns(expectedContactPerson);
             _organizationService.Setup(_ => _.GetDataResponsible(orgId)).Returns(expectedDataResponsible);

--- a/Tests.Unit.Presentation.Web/Services/OrganizationWriteServiceTest.cs
+++ b/Tests.Unit.Presentation.Web/Services/OrganizationWriteServiceTest.cs
@@ -158,7 +158,7 @@ namespace Tests.Unit.Presentation.Web.Services
         }
 
         [Fact]
-        public void Update_Master_Data_Roles_Returns_Bad_Input_If_Invalid_Uuid()
+        public void Update_Master_Data_Roles_Returns_Not_Found_If_Invalid_Uuid()
         {
             var invalidOrganizationUuid = A<Guid>();
             _identityResolver.Setup(_ =>
@@ -166,13 +166,14 @@ namespace Tests.Unit.Presentation.Web.Services
                 .Returns(Maybe<int>.None);
             var transaction = new Mock<IDatabaseTransaction>();
             _transactionManager.Setup(x => x.Begin()).Returns(transaction.Object);
+            _organizationService.Setup(_ => _.GetOrganization(invalidOrganizationUuid, null)).Returns(new OperationError(OperationFailure.NotFound));
 
             var result =
                 _sut.UpsertOrganizationMasterDataRoles(invalidOrganizationUuid, new OrganizationMasterDataRolesUpdateParameters());
 
             Assert.True(result.Failed);
             var error = result.Error;
-            Assert.Equal(OperationFailure.BadInput, error.FailureType);
+            Assert.Equal(OperationFailure.NotFound, error.FailureType);
         }
 
         [Fact]

--- a/Tests.Unit.Presentation.Web/Services/OrganizationWriteServiceTest.cs
+++ b/Tests.Unit.Presentation.Web/Services/OrganizationWriteServiceTest.cs
@@ -203,30 +203,6 @@ namespace Tests.Unit.Presentation.Web.Services
         }
 
         [Fact]
-        public void Update_Master_Data_Roles_Returns_Forbidden_If_Unauthorized_To_Modify_Contact_Person()
-        {
-            var org = GetOrgAndSetupForVerifyUnauthorized();
-            var orgId = org.Id;
-            var updateParameters = SetupUpdateMasterDataRoles(orgId);
-            _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<ContactPerson>()))
-                .Returns(false);
-            _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<DataResponsible>()))
-                .Returns(true);
-            _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<DataProtectionAdvisor>()))
-                .Returns(true);
-
-            var result =
-                _sut.UpsertOrganizationMasterDataRoles(org.Uuid, updateParameters);
-
-            Assert.True(result.Failed);
-            var error = result.Error;
-            Assert.Equal(OperationFailure.Forbidden, error.FailureType);
-        }
-
-        [Fact]
         public void Update_Master_Data_Roles_Returns_Forbidden_If_Unauthorized_To_Modify_Data_Protection_Advisor()
         {
             var org = GetOrgAndSetupForVerifyUnauthorized();

--- a/Tests.Unit.Presentation.Web/Services/OrganizationWriteServiceTest.cs
+++ b/Tests.Unit.Presentation.Web/Services/OrganizationWriteServiceTest.cs
@@ -176,63 +176,16 @@ namespace Tests.Unit.Presentation.Web.Services
         }
 
         [Fact]
-        public void Update_Master_Data_Roles_Returns_Forbidden_If_Unauthorized_To_Modify_Data_Responsible()
+        public void Update_Master_Data_Roles_Returns_Forbidden_If_Unauthorized_To_Modify_Root_Organization()
         {
             var org = GetOrgAndSetupForVerifyUnauthorized();
             var orgId = org.Id;
             var updateParameters = SetupUpdateMasterDataRoles(orgId);
-            _identityResolver.Setup(_ =>
-                    _.ResolveDbId<Organization>(org.Uuid))
-                .Returns(orgId);
+            _organizationService.Setup(_ => _.GetOrganization(org.Uuid, null)).Returns(org);
             _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<ContactPerson>()))
-                .Returns(true);
-            _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<DataResponsible>()))
+                    _.AllowModify(It.IsAny<Organization>()))
                 .Returns(false);
-            _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<DataProtectionAdvisor>()))
-                .Returns(true);
 
-            var result =
-                _sut.UpsertOrganizationMasterDataRoles(org.Uuid, updateParameters);
-
-            Assert.True(result.Failed);
-            var error = result.Error;
-            Assert.Equal(OperationFailure.Forbidden, error.FailureType);
-        }
-
-        [Fact]
-        public void Update_Master_Data_Roles_Returns_Forbidden_If_Unauthorized_To_Modify_Contact_Person()
-        {
-            var org = GetOrgAndSetupForVerifyUnauthorized();
-            var orgId = org.Id;
-            var updateParameters = SetupUpdateMasterDataRoles(orgId);
-            _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<ContactPerson>()))
-                .Returns(false);
-            _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<DataResponsible>()))
-                .Returns(true);
-            _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<DataProtectionAdvisor>()))
-                .Returns(true);
-
-            var result =
-                _sut.UpsertOrganizationMasterDataRoles(org.Uuid, updateParameters);
-
-            Assert.True(result.Failed);
-            var error = result.Error;
-            Assert.Equal(OperationFailure.Forbidden, error.FailureType);
-        }
-
-        [Fact]
-        public void Update_Master_Data_Roles_Returns_Forbidden_If_Unauthorized_To_Modify_Data_Protection_Advisor()
-        {
-            var org = GetOrgAndSetupForVerifyUnauthorized();
-            var orgId = org.Id;
-            var updateParameters = SetupUpdateMasterDataRoles(orgId);
-            
             var result =
                 _sut.UpsertOrganizationMasterDataRoles(org.Uuid, updateParameters);
 
@@ -316,9 +269,6 @@ namespace Tests.Unit.Presentation.Web.Services
             _organizationService.Setup(_ => _.GetOrganization(org.Uuid, null)).Returns(org);
             _authorizationContext.Setup(_ =>
                     _.AllowModify(It.IsAny<Organization>()))
-                .Returns(true);
-            _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<DataResponsible>()))
                 .Returns(true);
             _authorizationContext.Setup(_ =>
                     _.AllowModify(It.IsAny<DataProtectionAdvisor>()))

--- a/Tests.Unit.Presentation.Web/Services/OrganizationWriteServiceTest.cs
+++ b/Tests.Unit.Presentation.Web/Services/OrganizationWriteServiceTest.cs
@@ -175,48 +175,6 @@ namespace Tests.Unit.Presentation.Web.Services
             Assert.Equal(OperationFailure.BadInput, error.FailureType);
         }
 
-        [Fact]
-        public void Update_Master_Data_Roles_Returns_Forbidden_If_Unauthorized_To_Modify_Data_Responsible()
-        {
-            var org = GetOrgAndSetupForVerifyUnauthorized();
-            var orgId = org.Id;
-            var updateParameters = SetupUpdateMasterDataRoles(orgId);
-            _identityResolver.Setup(_ =>
-                    _.ResolveDbId<Organization>(org.Uuid))
-                .Returns(orgId);
-            _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<ContactPerson>()))
-                .Returns(true);
-            _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<DataResponsible>()))
-                .Returns(false);
-            _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<DataProtectionAdvisor>()))
-                .Returns(true);
-
-            var result =
-                _sut.UpsertOrganizationMasterDataRoles(org.Uuid, updateParameters);
-
-            Assert.True(result.Failed);
-            var error = result.Error;
-            Assert.Equal(OperationFailure.Forbidden, error.FailureType);
-        }
-
-        [Fact]
-        public void Update_Master_Data_Roles_Returns_Forbidden_If_Unauthorized_To_Modify_Data_Protection_Advisor()
-        {
-            var org = GetOrgAndSetupForVerifyUnauthorized();
-            var orgId = org.Id;
-            var updateParameters = SetupUpdateMasterDataRoles(orgId);
-            
-            var result =
-                _sut.UpsertOrganizationMasterDataRoles(org.Uuid, updateParameters);
-
-            Assert.True(result.Failed);
-            var error = result.Error;
-            Assert.Equal(OperationFailure.Forbidden, error.FailureType);
-        }
-
         public Organization GetOrgAndSetupForVerifyUnauthorized()
         {
             var org = CreateOrganization();

--- a/Tests.Unit.Presentation.Web/Services/OrganizationWriteServiceTest.cs
+++ b/Tests.Unit.Presentation.Web/Services/OrganizationWriteServiceTest.cs
@@ -313,8 +313,9 @@ namespace Tests.Unit.Presentation.Web.Services
                     _.ResolveDbId<Organization>(org.Uuid))
                 .Returns(expectedContactPerson.OrganizationId);
 
+            _organizationService.Setup(_ => _.GetOrganization(org.Uuid, null)).Returns(org);
             _authorizationContext.Setup(_ =>
-                    _.AllowModify(It.IsAny<ContactPerson>()))
+                    _.AllowModify(It.IsAny<Organization>()))
                 .Returns(true);
             _authorizationContext.Setup(_ =>
                     _.AllowModify(It.IsAny<DataResponsible>()))


### PR DESCRIPTION
This seems counterintuitive but complies with the implementation of the old UI - otherwise, local admins in an organization cannot change their own organization's master data roles.

## KITOS Pull request template
The following procedure dictates the steps needed before a Pull request can be merged into master.

- [x] **Implement**: 
      *All requirements are implemented and unit tests are green*
      
- [x] **Merge master into branch / rebase with master**: 
      *Make sure you are testing your changes and how they co-exist with the latest version of master*
      
- [ ] **Green on integration**: 
      *All integration tests are green on integration*
      
- [ ] **Request review**: 
      *Tag whomever you wish to review your code*
      
- [ ] **Review completed**: 
      *Reviewer ticks this box when review comments have been submitted*
      
- [ ] **Changes**: 
      *PR owner and reviewer agrees on which changes must be made and the changes are committed.*
      
- [ ] **Merge master into branch / rebase with master**: 
      *Make sure you are testing your changes and how they co-exist with the latest version of master*
      
- [ ] **Green on integration**: 
      *All integration tests are green on integration*
