### PR TITLE
Fix OPENJSON SQL syntax error in background job by setting compat level 120

### DIFF
--- a/Infrastructure.DataAccess/KitosContext.cs
+++ b/Infrastructure.DataAccess/KitosContext.cs
@@ -28,7 +28,7 @@ namespace Infrastructure.DataAccess
     {
         public KitosContext() : this(new DbContextOptionsBuilder<KitosContext>()
             .UseLazyLoadingProxies()
-            .UseSqlServer(ConnectionStringTools.GetConnectionString("KitosContext"))
+            .UseSqlServer(ConnectionStringTools.GetConnectionString("KitosContext"), o => o.UseCompatibilityLevel(120))
             .Options) { }
 
         public KitosContext(DbContextOptions<KitosContext> options) : base(options) { }

--- a/Infrastructure.DataAccess/KitosContextDesignTimeFactory.cs
+++ b/Infrastructure.DataAccess/KitosContextDesignTimeFactory.cs
@@ -26,7 +26,7 @@ namespace Infrastructure.DataAccess
                     "Example: $env:ConnectionStrings__KitosContext = \"Server=.\\SQLEXPRESS;Integrated Security=true;Initial Catalog=Kitos;MultipleActiveResultSets=True;TrustServerCertificate=True\"");
 
             var optionsBuilder = new DbContextOptionsBuilder<KitosContext>();
-            optionsBuilder.UseLazyLoadingProxies().UseSqlServer(connectionString);
+            optionsBuilder.UseLazyLoadingProxies().UseSqlServer(connectionString, o => o.UseCompatibilityLevel(120));
 
             return new KitosContext(optionsBuilder.Options);
         }

--- a/Presentation.Web/Infrastructure/DI/KitosServiceRegistration.cs
+++ b/Presentation.Web/Infrastructure/DI/KitosServiceRegistration.cs
@@ -417,7 +417,7 @@ namespace Presentation.Web.Infrastructure.DI
             {
                 var httpContextAccessor = sp.GetRequiredService<IHttpContextAccessor>();
                 options.UseLazyLoadingProxies()
-                    .UseSqlServer(connectionString)
+                    .UseSqlServer(connectionString, o => o.UseCompatibilityLevel(120))
                     .AddInterceptors(new EFEntityInterceptor(
                         operationClock: () =>
                             httpContextAccessor.HttpContext?.RequestServices.GetService<IOperationClock>()

--- a/PubSub.Application.Api/Configuration/ServiceCollectionExtensions.cs
+++ b/PubSub.Application.Api/Configuration/ServiceCollectionExtensions.cs
@@ -57,7 +57,7 @@ public static class ServiceCollectionExtensions
         services.AddDbContext<PubSubContext>(options =>
         {
             var connectionString = configuration.GetConnectionString("DefaultConnection");
-            options.UseSqlServer(connectionString);
+            options.UseSqlServer(connectionString, o => o.UseCompatibilityLevel(120));
         });
         return services;
     }

--- a/PubSub.Infrastructure.DataAccess/Factories/PubSubContextFactory.cs
+++ b/PubSub.Infrastructure.DataAccess/Factories/PubSubContextFactory.cs
@@ -10,7 +10,7 @@ namespace PubSub.Infrastructure.DataAccess.Factories
             var connectionString = Environment.GetEnvironmentVariable("DEFAULT_CONNECTION_STRING");
 
             var optionsBuilder = new DbContextOptionsBuilder<PubSubContext>();
-            optionsBuilder.UseSqlServer(connectionString);
+            optionsBuilder.UseSqlServer(connectionString, o => o.UseCompatibilityLevel(120));
             return new PubSubContext(optionsBuilder.Options);
         }
     }

--- a/Tests.Integration.Presentation.Web/Tools/TestEnvironment.cs
+++ b/Tests.Integration.Presentation.Web/Tools/TestEnvironment.cs
@@ -129,7 +129,7 @@ namespace Tests.Integration.Presentation.Web.Tools
         {
             var options = new DbContextOptionsBuilder<KitosContext>()
                 .UseLazyLoadingProxies()
-                .UseSqlServer(ConnectionString)
+                .UseSqlServer(ConnectionString, o => o.UseCompatibilityLevel(120))
                 .Options;
             return new KitosContext(options);
         }

--- a/Tools.Test.Database/Program.cs
+++ b/Tools.Test.Database/Program.cs
@@ -28,7 +28,7 @@ namespace Tools.Test.Database
                 FailOnConnectionToProd(connectionString);
                 var dbOptions = new DbContextOptionsBuilder<KitosContext>()
                     .UseLazyLoadingProxies()
-                    .UseSqlServer(connectionString)
+                    .UseSqlServer(connectionString, o => o.UseCompatibilityLevel(120))
                     .Options;
                 using (var context = new KitosContext(dbOptions))
                 {


### PR DESCRIPTION
## Why

The `purge-duplicate-read-model-updates` background job fails with:

```
Microsoft.Data.SqlClient.SqlException: Incorrect syntax near '$'.
```

This happens because EF Core 10 translates `Contains()` on parameterized collections to `OPENJSON(@param) WITH ([Value] int '$')` by default. Our SQL Server database's compatibility level is below 130, so `OPENJSON` is not available.

## Approach

Added `UseCompatibilityLevel(120)` to all `UseSqlServer()` calls across the solution. This instructs EF Core to generate traditional `WHERE Id IN (...)` SQL instead of relying on `OPENJSON`.

All seven call sites are updated consistently:
- `Infrastructure.DataAccess/KitosContext.cs`
- `Infrastructure.DataAccess/KitosContextDesignTimeFactory.cs`
- `Presentation.Web/Infrastructure/DI/KitosServiceRegistration.cs`
- `Tools.Test.Database/Program.cs`
- `Tests.Integration.Presentation.Web/Tools/TestEnvironment.cs`
- `PubSub.Application.Api/Configuration/ServiceCollectionExtensions.cs`
- `PubSub.Infrastructure.DataAccess/Factories/PubSubContextFactory.cs`

## Notes

- If the database is later upgraded to compatibility level 130+, this value can be raised to re-enable the more efficient `OPENJSON` path.
- No behavioral change beyond the SQL translation strategy -- query results are identical.