### PR TITLE
Add root docker-compose.yml with EF migration support

### DIFF
--- a/DeploymentScripts/docker/init-databases.sh
+++ b/DeploymentScripts/docker/init-databases.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+# This script is mounted into the PostgreSQL container as an init script.
+# It creates the required databases and a shared application user.
+
+POSTGRES_USER="${POSTGRES_USER:-postgres}"
+APP_USER="${APP_USER:-kitos}"
+APP_PASSWORD="${APP_PASSWORD:-kitos}"
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "postgres" <<-EOSQL
+    -- Create application user
+    DO \$\$
+    BEGIN
+        IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${APP_USER}') THEN
+            CREATE ROLE ${APP_USER} WITH LOGIN PASSWORD '${APP_PASSWORD}';
+        END IF;
+    END
+    \$\$;
+
+    -- Create databases
+    SELECT 'CREATE DATABASE kitos OWNER ${APP_USER}'
+        WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'kitos')\gexec
+
+    SELECT 'CREATE DATABASE kitos_hangfire OWNER ${APP_USER}'
+        WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'kitos_hangfire')\gexec
+
+    SELECT 'CREATE DATABASE kitos_pubsub OWNER ${APP_USER}'
+        WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'kitos_pubsub')\gexec
+
+    -- Grant privileges
+    GRANT ALL PRIVILEGES ON DATABASE kitos TO ${APP_USER};
+    GRANT ALL PRIVILEGES ON DATABASE kitos_hangfire TO ${APP_USER};
+    GRANT ALL PRIVILEGES ON DATABASE kitos_pubsub TO ${APP_USER};
+EOSQL
+
+# Connect to each database and grant schema privileges
+for db in kitos kitos_hangfire kitos_pubsub; do
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$db" <<-EOSQL
+        GRANT ALL ON SCHEMA public TO ${APP_USER};
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO ${APP_USER};
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO ${APP_USER};
+EOSQL
+done

--- a/Presentation.Web/Program.cs
+++ b/Presentation.Web/Program.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Presentation.Web;
@@ -58,6 +59,17 @@ services.AddHttpContextAccessor();
 KitosServiceRegistration.Register(services, configuration, signingKey);
 
 var app = builder.Build();
+
+// Support --migrate-and-exit for running EF migrations in init-containers or compose services
+if (args.Contains("--migrate-and-exit", StringComparer.OrdinalIgnoreCase))
+{
+    using var scope = app.Services.CreateScope();
+    var db = scope.ServiceProvider.GetRequiredService<Infrastructure.DataAccess.KitosContext>();
+    Log.Information("Applying pending EF Core migrations...");
+    db.Database.Migrate();
+    Log.Information("Migrations applied successfully.");
+    return;
+}
 
 // Initialize the SAML library's static HTTP context accessor so it can access HttpContext.Current
 // during SAML flows without requiring DI injection into the (statically-instantiated) handler classes.

--- a/PubSub.Application.Api/Dockerfile
+++ b/PubSub.Application.Api/Dockerfile
@@ -19,6 +19,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/out .
 
-EXPOSE 443
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
 
 ENTRYPOINT ["dotnet", "PubSub.Application.Api.dll"]

--- a/PubSub.Application.Api/Program.cs
+++ b/PubSub.Application.Api/Program.cs
@@ -14,17 +14,16 @@ builder.Configuration
 
 builder.WebHost.ConfigureKestrel((context, options) =>
 {
+    if (context.HostingEnvironment.IsDevelopment())
+    {
+        // In development/Docker, listen on HTTP (port configured via ASPNETCORE_URLS)
+        return;
+    }
+
     options.ListenAnyIP(443, listenOptions =>
     {
-        if (context.HostingEnvironment.IsDevelopment())
-        {
-            listenOptions.UseHttps();
-        }
-        else
-        {
-            var certPassword = Environment.GetEnvironmentVariable(Constants.Config.Certificate.CertPassword);
-            listenOptions.UseHttps(Constants.Config.Certificate.CertFilePath, certPassword);
-        }
+        var certPassword = Environment.GetEnvironmentVariable(Constants.Config.Certificate.CertPassword);
+        listenOptions.UseHttps(Constants.Config.Certificate.CertFilePath, certPassword);
     });
 });
 
@@ -48,6 +47,15 @@ var app = builder.Build();
 using (var scope = app.Services.CreateScope())
 {
     var context = scope.ServiceProvider.GetRequiredService<PubSubContext>();
+
+    if (args.Contains("--migrate-and-exit", StringComparer.OrdinalIgnoreCase))
+    {
+        Console.WriteLine("Applying pending EF Core migrations for PubSub...");
+        context.Database.Migrate();
+        Console.WriteLine("Migrations applied successfully.");
+        return;
+    }
+
     var pendingMigrations = context.Database.GetPendingMigrations().ToArray();
     if (pendingMigrations.Any())
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,135 @@
+# KITOS Local Development - Docker Compose
+#
+# Usage: docker compose up
+#
+# NOTE: The legacy AngularJS frontend is served directly by the kitos-api (ASP.NET).
+# The new frontend (https://github.com/os2kitos/kitos_frontend) is a separate repo
+# and is NOT included in this compose file.
+#
+# For Kubernetes deployments, EF migrations should run as init-containers rather than
+# at application startup. See the migrate-db service below for the local equivalent.
+
+services:
+  postgres:
+    image: postgres:17
+    container_name: kitos-postgres
+    environment:
+      POSTGRES_PASSWORD: postgres
+      APP_USER: kitos
+      APP_PASSWORD: kitos
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./DeploymentScripts/docker/init-databases.sh:/docker-entrypoint-initdb.d/init-databases.sh:ro
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: kitos-rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  # Runs EF Core migrations for the main KITOS database before the API starts.
+  # This mirrors the init-container pattern used in Kubernetes.
+  migrate-db:
+    build:
+      context: .
+      dockerfile: Presentation.Web/Dockerfile
+    container_name: kitos-migrate-db
+    entrypoint: ["dotnet", "Presentation.Web.dll", "--migrate-and-exit"]
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      Database__Provider: PostgreSql
+      ConnectionStrings__KitosContext: "Host=postgres;Port=5432;Database=kitos;Username=kitos;Password=kitos"
+      ConnectionStrings__kitos_HangfireDB: "Host=postgres;Port=5432;Database=kitos_hangfire;Username=kitos;Password=kitos"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  kitos-api:
+    build:
+      context: .
+      dockerfile: Presentation.Web/Dockerfile
+    container_name: kitos-api
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      Database__Provider: PostgreSql
+      Hangfire__Provider: PostgreSql
+      ConnectionStrings__KitosContext: "Host=postgres;Port=5432;Database=kitos;Username=kitos;Password=kitos"
+      ConnectionStrings__kitos_HangfireDB: "Host=postgres;Port=5432;Database=kitos_hangfire;Username=kitos;Password=kitos"
+      AppSettings__BaseUrl: "http://localhost:5000"
+      AppSettings__PubSubBaseUrl: "http://pubsub-api:8080"
+      Serilog__WriteTo__0__Args__path: "/var/log/kitos/kitos-.txt"
+      Smtp__DeliveryMethod: SpecifiedPickupDirectory
+      Smtp__PickupDirectoryLocation: "/tmp/maildrop/"
+    ports:
+      - "5000:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      migrate-db:
+        condition: service_completed_successfully
+
+  # Runs EF Core migrations for the PubSub database.
+  migrate-pubsub-db:
+    build:
+      context: .
+      dockerfile: PubSub.Application.Api/Dockerfile
+    container_name: kitos-migrate-pubsub-db
+    entrypoint: ["dotnet", "PubSub.Application.Api.dll", "--migrate-and-exit"]
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      Database__Provider: PostgreSql
+      ConnectionStrings__DefaultConnection: "Host=postgres;Port=5432;Database=kitos_pubsub;Username=kitos;Password=kitos"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  pubsub-api:
+    build:
+      context: .
+      dockerfile: PubSub.Application.Api/Dockerfile
+    container_name: kitos-pubsub-api
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      Database__Provider: PostgreSql
+      ConnectionStrings__DefaultConnection: "Host=postgres;Port=5432;Database=kitos_pubsub;Username=kitos;Password=kitos"
+      JwtValidation__ApiUrl: "http://kitos-api:8080"
+      JwtValidation__ValidationEndpoint: "/api/v2/token/validate"
+      RabbitMQ__HostName: rabbitmq
+      RABBIT_MQ_USER: guest
+      RABBIT_MQ_PASSWORD: guest
+      PUBSUB_API_KEY: "local-no-secret"
+    ports:
+      - "5100:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      kitos-api:
+        condition: service_started
+      migrate-pubsub-db:
+        condition: service_completed_successfully
+
+volumes:
+  postgres_data:
+  rabbitmq_data:

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -1,0 +1,114 @@
+# Running KITOS with Docker Compose
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) (v20.10+)
+- [Docker Compose](https://docs.docker.com/compose/install/) (v2.0+)
+
+## Quick Start
+
+From the repository root:
+
+```bash
+docker compose up
+```
+
+This starts the full KITOS stack. First run will build images and apply database migrations automatically.
+
+## Services
+
+| Service | Port | Description |
+|---------|------|-------------|
+| **kitos-api** | [localhost:5000](http://localhost:5000) | Main KITOS API + legacy AngularJS UI |
+| **pubsub-api** | [localhost:5100](http://localhost:5100) | PubSub API (event messaging) |
+| **postgres** | localhost:5432 | PostgreSQL 17 (3 databases) |
+| **rabbitmq** | [localhost:15672](http://localhost:15672) | RabbitMQ management UI |
+
+## Databases
+
+PostgreSQL is initialized with three databases:
+
+| Database | Purpose |
+|----------|---------|
+| `kitos` | Main application database |
+| `kitos_hangfire` | Background job storage (Hangfire) |
+| `kitos_pubsub` | PubSub event messaging database |
+
+**Credentials:** `kitos` / `kitos` (user/password)
+
+## Common Commands
+
+```bash
+# Start all services (foreground)
+docker compose up
+
+# Start in background
+docker compose up -d
+
+# Rebuild images after code changes
+docker compose up --build
+
+# Stop all services
+docker compose down
+
+# Stop and remove volumes (reset databases)
+docker compose down -v
+
+# View logs for a specific service
+docker compose logs -f kitos-api
+
+# Run only migrations (useful for debugging)
+docker compose run --rm migrate-db
+docker compose run --rm migrate-pubsub-db
+```
+
+## How Migrations Work
+
+Database migrations run automatically before the APIs start:
+
+1. `migrate-db` service applies EF Core migrations to the `kitos` database
+2. `migrate-pubsub-db` service applies migrations to `kitos_pubsub`
+3. APIs only start after their respective migration service exits successfully
+
+This mirrors the Kubernetes init-container pattern.
+
+## Environment Variables
+
+Key environment variables can be overridden in a `.env` file at the repo root:
+
+```env
+# Example overrides
+POSTGRES_PASSWORD=custom_password
+APP_USER=custom_user
+APP_PASSWORD=custom_password
+```
+
+## Troubleshooting
+
+### Port conflicts
+
+If ports 5000, 5100, 5432, 5672, or 15672 are in use, stop conflicting services or modify the port mappings in `docker-compose.yml`.
+
+### Database issues
+
+Reset the database state:
+
+```bash
+docker compose down -v
+docker compose up
+```
+
+### Build failures
+
+Ensure you're building from the repo root (where `docker-compose.yml` lives):
+
+```bash
+docker compose build --no-cache
+```
+
+## Notes
+
+- The legacy AngularJS frontend is served directly by `kitos-api` (ASP.NET)
+- The [new frontend](https://github.com/os2kitos/kitos_frontend) is a separate repository and not included in this compose setup
+- RabbitMQ management UI uses default credentials: `guest` / `guest`
+- Mail is configured to use a pickup directory (`/tmp/maildrop/`) — no SMTP server needed for local dev


### PR DESCRIPTION
## Summary

Adds a self-contained `docker-compose.yml` at the repo root for local development. Running `docker compose up` starts the full KITOS stack with PostgreSQL, RabbitMQ, and both APIs.

### Changes

**New files:**
- `docker-compose.yml` — orchestrates all services (postgres, rabbitmq, kitos-api, pubsub-api, migration services)
- `DeploymentScripts/docker/init-databases.sh` — PostgreSQL init script that creates `kitos`, `kitos_hangfire`, and `kitos_pubsub` databases with a shared `kitos` user

**Modified files:**
- `Presentation.Web/Program.cs` — adds `--migrate-and-exit` CLI flag to run EF Core migrations and exit (used by `migrate-db` compose service)
- `PubSub.Application.Api/Program.cs` — adds `--migrate-and-exit` flag; fixes Kestrel to skip HTTPS in Development
- `PubSub.Application.Api/Dockerfile` — changes exposed port from 443 to 8080, adds `ASPNETCORE_URLS` env var

### Architecture

```
docker compose up
├── postgres (creates 3 DBs via init script)
├── rabbitmq
├── migrate-db (runs EF migrations for kitos DB, then exits)
├── migrate-pubsub-db (runs EF migrations for pubsub DB, then exits)
├── kitos-api (depends on migrate-db success)
└── pubsub-api (depends on migrate-pubsub-db success + kitos-api)
```

The migration services mirror the Kubernetes init-container pattern — they run migrations before the API starts, ensuring the schema is up-to-date.

### Notes
- The legacy AngularJS frontend is served by the kitos-api (ASP.NET), no separate frontend container needed
- The new frontend (os2kitos/kitos_frontend) is external and not included
- Base branch: `strongmindsaln/linux-enable-and-dockerfile`